### PR TITLE
feat: add Rho academic article template

### DIFF
--- a/examples/demo-rho.md
+++ b/examples/demo-rho.md
@@ -1,0 +1,98 @@
+---
+template: rho
+title: "Template for preparing an academic article using the Rho LaTeX class with Inkwell"
+journalname: "Example Template"
+rho-authors:
+  - name: "Author One"
+    superscript: "1,*"
+  - name: "Author Two"
+    superscript: "2"
+  - name: "Author Three"
+    superscript: "3,*"
+rho-affiliations:
+  - superscript: "1"
+    text: "Affiliation of author one"
+  - superscript: "2"
+    text: "Affiliation of author two"
+  - superscript: "3"
+    text: "Affiliation of author three"
+  - superscript: "*"
+    text: "These authors contributed equally to this work"
+dates: "This manuscript was compiled on February 22, 2026"
+leadauthor: "Author et al."
+footinfo: "Creative Commons CC BY 4.0"
+smalltitle: "Rho Template"
+institution: "University Name"
+theday: "February 22, 2026"
+corres: "Provide the corresponding author information here."
+email: "example@organization.com"
+doi: "https://www.doi.org/exampledoi/XXXXXXXXXX"
+received: "January 10, 2026"
+revised: "February 1, 2026"
+accepted: "February 15, 2026"
+published: "February 22, 2026"
+license: "This document is licensed under Creative Commons CC BY 4.0."
+abstract: |
+  This document demonstrates the Rho LaTeX class rendered through
+  Inkwell's Pandoc pipeline. Rho provides a two-column academic
+  article layout with colored section headers, a styled abstract box,
+  corresponding-author metadata, and footer fields. All of these are
+  controlled from YAML frontmatter: no LaTeX editing required.
+keywords: "Inkwell, Pandoc, Rho class, academic template, reproducible documents"
+bibliography: references/refs.bib
+link-citations: true
+figPrefix: "figure"
+tblPrefix: "table"
+eqnPrefix: "equation"
+---
+
+# Introduction
+
+The Rho LaTeX class provides a polished two-column layout for academic articles and lab reports. Originally designed for Overleaf, it is adapted here as an Inkwell template so that authors can write in markdown and produce publication-quality PDFs.
+
+Rho's visual identity includes colored section headers, a tinted abstract box with keywords, and a corresponding-author block with dates, DOI, and license. All metadata is set in the YAML frontmatter above.
+
+# Equations
+
+The Schrodinger equation serves as a typesetting example:
+
+$$\frac{\hbar^2}{2m}\nabla^2\Psi + V(\mathbf{r})\Psi = -i\hbar \frac{\partial\Psi}{\partial t}$$ {#eq:schrodinger}
+
+@Eq:schrodinger renders through Pandoc's `tex_math_dollars` extension. The `stix2` font bundled with Rho provides high-quality mathematical symbols without additional packages.
+
+# Code Highlighting
+
+Pandoc syntax highlighting works alongside Rho's built-in listings style. Fenced code blocks produce colored output:
+
+```python
+import numpy as np
+
+def fourier_partial_sum(x, n_terms):
+    """Compute the n-term Fourier partial sum of a square wave."""
+    result = np.zeros_like(x)
+    for k in range(1, n_terms + 1):
+        result += (4 / ((2 * k - 1) * np.pi)) * np.sin((2 * k - 1) * x)
+    return result
+```
+
+# Tables
+
+Pandoc pipe tables compile into single-column table floats. Rho's caption style applies automatically.
+
+| Day       | Min Temp | Max Temp | Summary                          |
+|-----------|----------|----------|----------------------------------|
+| Monday    | 11 C     | 22 C     | Clear skies, strong breeze       |
+| Tuesday   | 9 C      | 19 C     | Cloudy with rain in the north    |
+| Wednesday | 10 C     | 21 C     | Morning rain, clearing by noon   |
+
+: Weekly forecast example. {#tbl:forecast}
+
+# Cross-References
+
+Pandoc-crossref handles numbered references: @Eq:schrodinger for equations, @Tbl:forecast for tables. Section numbers, figure labels, and bibliography citations [@macfarlane2023] all resolve in the compiled output.
+
+# Conclusion
+
+This demo confirms that the Rho template integrates with Inkwell's compilation pipeline. Authors write standard markdown with YAML frontmatter, and the extension produces a two-column PDF matching Rho's original LaTeX design.
+
+## References

--- a/templates/rho/example.m
+++ b/templates/rho/example.m
@@ -1,0 +1,23 @@
+function fibonacci_sequence(num_terms)
+    % Initialize the first two terms of the sequence
+    fib_sequence = [0, 1];
+    
+    if num_terms < 1
+        disp('Number of terms should be greater than or equal to 1.');
+        return;
+    elseif num_terms == 1
+        fprintf('Fibonacci Sequence:\n%d\n', fib_sequence(1));
+        return;
+    elseif num_terms == 2
+        fprintf('Fibonacci Sequence:\n%d\n%d\n', fib_sequence(1), fib_sequence(2));
+        return;
+    end
+    
+    % Calculate and display the Fibonacci sequence
+    for i = 3:num_terms
+        fib_sequence(i) = fib_sequence(i-1) + fib_sequence(i-2);
+    end
+    
+    fprintf('Fibonacci Sequence:\n');
+    disp(fib_sequence);
+end 

--- a/templates/rho/rho-class/rho.cls
+++ b/templates/rho/rho-class/rho.cls
@@ -1,0 +1,506 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+% Rho
+% LaTeX Class
+% Version 2.1.1 (01/09/2024)
+%
+% Authors: 
+% Guillermo Jimenez (memo.notess1@gmail.com)
+% Eduardo Gracidas (eduardo.gracidas29@gmail.com)
+% 
+% License:
+% Creative Commons CC BY 4.0
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+% You may modify 'rho.cls' file according to your
+% needs and preferences. This LaTeX class file defines 
+% the document layout and behavior.
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+% 						 WARNING!
+% --------------------------------------------------------
+% It is important to proceed with caution and ensure that 
+% any modifications made are compatible with LaTeX 
+% syntax and conventions to avoid errors or unexpected 
+% behavior in the document compilation process.
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%----------------------------------------------------------
+% CLASS CONFIGURATION
+%----------------------------------------------------------
+
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{rho-class/rho}[2024/09/01 Rho LaTeX class]
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{extarticle}}
+\ProcessOptions\relax
+\LoadClass[twocolumn]{extarticle} % onecolumn
+\AtEndOfClass{\RequirePackage{microtype}}
+
+%----------------------------------------------------------
+% REQUIRED PACKAGES
+%----------------------------------------------------------
+
+\RequirePackage[utf8]{inputenc}
+\RequirePackage{etoolbox}
+\RequirePackage[framemethod=tikz]{mdframed}
+\RequirePackage{titling}
+\RequirePackage{lettrine}
+\RequirePackage[switch]{lineno}
+\RequirePackage{microtype}
+\RequirePackage[bottom,hang,flushmargin,ragged]{footmisc}
+\RequirePackage{fancyhdr}
+\RequirePackage{xifthen}
+\RequirePackage{adjustbox}
+\RequirePackage{adforn}
+\RequirePackage{lastpage}
+\RequirePackage[explicit]{titlesec}
+\RequirePackage{booktabs}
+\RequirePackage{array} 
+\RequirePackage{caption}
+\RequirePackage{setspace}
+\RequirePackage{iflang}
+\RequirePackage{listings}
+\RequirePackage{lipsum}
+\RequirePackage{fontawesome5}       % For icons
+\RequirePackage{chemfig}            % Chemical structures
+\RequirePackage{circuitikz}         % Circuits schematics
+\RequirePackage{supertabular}
+\RequirePackage{matlab-prettifier}
+\RequirePackage{listings}
+\RequirePackage{csquotes}
+\RequirePackage{ragged2e}
+\RequirePackage{ccicons}
+\RequirePackage{imakeidx}
+\RequirePackage{subcaption}
+\RequirePackage{stfloats} 
+\RequirePackage{authblk}
+% \RequirePackage{pbalance}         % Balances the last columns
+
+%----------------------------------------------------------
+% RHO CUSTOM PACKAGES (location/name)
+%----------------------------------------------------------
+
+\RequirePackage{rho-class/rhobabel}
+\RequirePackage{rho-class/rhoenvs}
+
+%----------------------------------------------------------
+% CORRESPONDING AUTHOR SECTION-, ABTRACT-, NEWBOOL
+%----------------------------------------------------------
+
+\newbool{corres-info}
+\newbool{rho-abstract}
+
+%----------------------------------------------------------
+% PAGE LAYOUT
+%----------------------------------------------------------
+
+\RequirePackage[
+    left=1.25cm, 
+    right=1.25cm, 
+    top=2cm, 
+    bottom=2cm, 
+    headsep=0.75cm
+]{geometry}
+\setlength{\columnsep}{15pt}
+
+%----------------------------------------------------------
+% PACKAGES FOR FIGURES
+%----------------------------------------------------------
+
+\usepackage{graphicx}
+\RequirePackage{here}
+\graphicspath{{figures/}{./}} 
+
+%----------------------------------------------------------
+% PACKAGES FOR BOXES
+%----------------------------------------------------------
+
+\RequirePackage{adjustbox}
+\RequirePackage{colortbl}
+\RequirePackage{tcolorbox}
+
+%----------------------------------------------------------
+% MATH PACKAGES
+%----------------------------------------------------------
+
+%!TEX In case of using another font that is not stix2 uncomment 'amssymb'
+
+\RequirePackage{amsmath}
+\RequirePackage{amsfonts}
+\RequirePackage{mathtools}
+% \RequirePackage{amssymb}
+
+% Equation skip value
+\newlength{\eqskip}\setlength{\eqskip}{8pt}
+\expandafter\def\expandafter\normalsize\expandafter{%
+    \normalsize%
+    \setlength\abovedisplayskip{\eqskip}%
+    \setlength\belowdisplayskip{\eqskip}%
+    \setlength\abovedisplayshortskip{\eqskip-\baselineskip}%
+    \setlength\belowdisplayshortskip{\eqskip}%
+}
+
+%----------------------------------------------------------
+% FONTS
+%----------------------------------------------------------
+
+\usepackage[notextcomp]{stix2}
+\RequirePackage[scaled]{helvet}
+\renewcommand{\ttdefault}{lmtt}
+
+%----------------------------------------------------------
+% URLs STYLE
+%----------------------------------------------------------
+
+\RequirePackage{url}
+\RequirePackage{xurl}
+\renewcommand\UrlFont{\selectfont}
+
+%----------------------------------------------------------
+
+\RequirePackage[colorlinks=true, allcolors=rhocolor]{hyperref}
+\RequirePackage{cleveref}
+\RequirePackage{bookmark}
+
+%----------------------------------------------------------
+% ITEMS
+%----------------------------------------------------------
+
+\RequirePackage{enumitem}
+\setlist{noitemsep}
+
+%----------------------------------------------------------
+% FIRST PAGE-, HEADER AND FOOTER
+%----------------------------------------------------------
+
+% New commands
+\newcommand{\footerfont}{\normalfont\sffamily\fontsize{7}{9}\selectfont}
+\newcommand{\institution}[1]{\def\@institution{#1}}
+\newcommand{\leadauthor}[1]{\def\@leadauthor{#1}}
+\newcommand{\footinfo}[1]{\def\@footinfo{#1}}
+\newcommand{\smalltitle}[1]{\def\@smalltitle{#1}}
+\newcommand{\theday}[1]{\def\@theday{#1}}
+
+\pagestyle{fancy}
+   \pagenumbering{arabic}
+
+% First page style
+\fancypagestyle{firststyle}{
+    \fancyfoot[R]{
+        {\ifx\@institution\undefined\else\footerfont\@institution\hspace{10pt}\fi}
+        {\ifx\@theday\undefined\else\footerfont\bfseries\@theday\hspace{10pt}\fi}
+        {\ifx\@smalltitle\undefined\else\footerfont\@smalltitle\hspace{10pt}\fi}
+        {\footerfont\textbf\thepage\textendash\pageref{LastPage}}
+    }
+    \fancyfoot[L]{\ifx\@footinfo\undefined\else\footerfont\@footinfo\fi}
+    \fancyfoot[C]{}
+    \fancyhead[C]{}
+    \fancyhead[R]{}
+    \fancyhead[L]{}
+}
+
+% Header
+\fancyhead[RO,LE]{\ifx\@title\undefined\else\footerfont\@title\fi}
+\fancyhead[RE,LO]{\ifx\@leadauthor\undefined\else\footerfont\@leadauthor\fi}
+
+% Footer
+\fancyfoot[C]{\footerfont\thepage\textendash\pageref{LastPage}}
+
+\renewcommand{\headrulewidth}{0pt} % No header rule
+\renewcommand{\footrulewidth}{0pt} % No footer rule
+
+%----------------------------------------------------------
+% RHO START ~ LETTRINE
+%----------------------------------------------------------
+
+\newcommand{\dropcapfont}{\color{rhocolor}\bfseries\fontsize{25pt}{28pt}\selectfont}
+\newcommand{\rhostart}[1]{\lettrine[lines=2,lraise=0,findent=2pt, nindent=0em]{{\dropcapfont{#1}}}{}}
+
+%----------------------------------------------------------
+% CORRESPONDING AUTHOR SECTION
+%----------------------------------------------------------
+
+% New commands
+\newcommand{\rhoinfofont}{\color{black}\normalfont\sffamily\linespread{1}\fontsize{7.8}{9}\selectfont}
+\newcommand{\received}[1]{\def\@received{#1}}
+\newcommand{\revised}[1]{\def\@revised{#1}}
+\newcommand{\accepted}[1]{\def\@accepted{#1}}
+\newcommand{\published}[1]{\def\@published{#1}}
+\newcommand{\corres}[1]{\def\@corres{#1}}
+\newcommand{\email}[1]{\def\@email{#1}}
+\newcommand{\doi}[1]{\def\@doi{#1}}
+\newcommand{\license}[1]{\def\@license{#1}}
+
+\newcommand{\rhoinfo}{
+    \rhoinfofont
+        \vskip5pt
+            {\ifx\@corres\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\correslanguage}\@corres\fi} 
+            {\ifx\@email\undefined\else\textcolor{rhocolor}{\itshape\ignorespaces\emaillanguage}\@email\fi\par}
+            {\ifx\@doi\undefined\else\textcolor{rhocolor}{\bfseries DOI: }\@doi\fi\par}
+            {\ifx\@received\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\receivedlanguage}\@received\hspace{10pt}\fi}
+            {\ifx\@revised\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\revisedlanguage}\@revised\hspace{10pt}\fi} 
+            {\ifx\@accepted\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\acceptedlanguage}\@accepted\hspace{10pt}\fi}
+            {\ifx\@published\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\publishedlanguage}\@published\fi\par}
+                \vskip3pt
+            {\@license\par}
+         \vskip1pt
+        \rule{\textwidth}{0.3pt}
+}
+
+%----------------------------------------------------------
+% ABSTRACT STYLE
+%----------------------------------------------------------
+
+% Abstract text style new commands
+\newcommand{\keywords}[1]{\def\@keywords{#1}}
+\newcommand{\absfont}{\color{black}\normalfont\sffamily\linespread{1}\fontsize{8.5}{11}\selectfont}
+\newcommand{\absheadfont}{\color{rhocolor}\normalfont\sffamily\fontsize{9}{11}\selectfont}
+\newcommand{\keywordsfont}{\normalfont\sffamily\itshape\linespread{1}\fontsize{7.8}{9}\selectfont}
+\newcommand{\keywordheadfont}{\normalfont\sffamily\fontsize{7.8}{9}\selectfont\bfseries}
+
+% Abstract definition
+\def\xabstract{abstract}
+\long\def\abstract#1\end#2{
+    \def\two{#2}\ifx\two\xabstract
+    \long\gdef\theabstract{\ignorespaces#1}
+    \def\go{\end{abstract}}
+\else
+    #1\end{#2}
+    \gdef\theabstract{\vskip12pt 
+    \vskip12pt}
+    \let\go\relax\fi
+\go}
+
+% Rho class abstract style 
+\newcommand{\rhoabstract}{
+    \begin{tcolorbox}[colback=rhocolor!22, arc=0pt, boxrule=0pt, left=5pt, right=5pt, top=5pt, bottom=5pt]
+        \ifx\@keywords\undefined
+            \absheadfont\bfseries\abstractname\vskip0.5em\absfont\theabstract\vskip10pt
+        \else
+            \absheadfont\bfseries\abstractname\vskip0.5em\absfont\theabstract\vskip10pt
+            \keywordsfont\keywordname\hspace{0.1em}\keywordsfont\@keywords
+        \fi
+    \end{tcolorbox}
+}
+
+%----------------------------------------------------------
+% TITLE STYLE
+%----------------------------------------------------------
+
+% New commands
+\newcommand{\journalname}[1]{\def\@journalname{#1}}
+\newcommand{\dates}[1]{\def\@dates{#1}}
+\newcommand{\datesfont}{\fontsize{7.5}{9}\selectfont}
+
+\renewcommand{\@maketitle}{
+    \bgroup\setlength{\parindent}{0pt}
+    {
+        {\ifx\@journalname\undefined\vskip-18pt\else\vskip-25pt\RaggedRight\sffamily\bfseries\fontsize{8}{14}\selectfont\@journalname\par\fi}
+        {\RaggedRight\color{rhocolor}\sffamily\bfseries\fontsize{16}{22}\selectfont\@title\par}
+        \vskip10pt
+            {\RaggedRight\@author\par}
+        \vskip8pt
+            {\ifx\@dates\undefined\vskip2pt\else\RaggedRight\datesfont\@dates\par\vskip15pt\fi}
+        \ifbool{rho-abstract}{\justify\rhoabstract}{}
+        \ifbool{corres-info}{\RaggedRight\rhoinfo}{}
+    } 
+    \egroup
+    \vskip12pt
+}
+
+%----------------------------------------------------------
+% AFFILIATION SETUP
+%----------------------------------------------------------
+
+\setlength{\affilsep}{9pt}
+\renewcommand\Authfont{\fontsize{9}{11}\bfseries\sffamily\selectfont}
+\renewcommand\Affilfont{\fontsize{7.5}{9}\it\selectfont}
+\renewcommand\AB@affilsep{\reset@font\protect\Affilfont}
+\renewcommand\AB@affilsepx{\reset@font\protect\\\protect\Affilfont}
+% \renewcommand\AB@affilsepx{, \protect\Affilfont}
+
+% Authands language
+\renewcommand\Authand{\ignorespaces\andlanguage }
+\renewcommand\Authands{\ignorespaces\andlanguage }
+
+%----------------------------------------------------------
+% SECTION STYLE
+%----------------------------------------------------------
+
+\setcounter{secnumdepth}{5}
+
+\titleformat{\section}
+    {\color{rhocolor}\sffamily\large\bfseries}
+    {\thesection.}
+    {0.5em}
+    {#1}
+    []
+
+\titleformat{name=\section,numberless}[block]
+    {\color{rhocolor}\sffamily\large\bfseries}
+    {}
+    {0em}
+    {\tikz\draw[rhocolor, fill=rhocolor] (0,0) rectangle (6.6pt,6.6pt); \hspace{2.5pt} {#1}}
+    []
+  
+\titleformat{\subsection}[block]
+    {\sffamily\bfseries}
+    {\thesubsection.}
+    {0.5em}
+    {#1}     
+    []
+  
+\titleformat{\subsubsection}[block] % You may change it to "runin"
+    {\small\sffamily\bfseries\itshape}
+    {\thesubsubsection.}
+    {0.5em}
+    {#1}      % If using runin, change #1 to '#1. ' (space at the end)
+    []    
+  
+\titleformat{\paragraph}[runin]
+    {\small\bfseries}
+    {}
+    {0em}
+    {#1} 
+  
+\titlespacing*{\section}{0pc}{3ex \@plus4pt \@minus3pt}{5pt}
+\titlespacing*{\subsection}{0pc}{2.5ex \@plus3pt \@minus2pt}{2pt}
+\titlespacing*{\subsubsection}{0pc}{2ex \@plus2.5pt \@minus1.5pt}{2pt}
+\titlespacing*{\paragraph}{0pc}{1.5ex \@plus2pt \@minus1pt}{12pt}
+
+%----------------------------------------------------------
+% TABLE OF CONTENTS
+%----------------------------------------------------------
+
+\newlength{\tocsep} 
+\setlength\tocsep{1.5pc} % Sets the indentation of the sections in the table of contents
+\setcounter{tocdepth}{5} % Three levels in the table of contents section: sections, subsections and subsubsections
+
+\usepackage{titletoc}
+\contentsmargin{0cm}
+
+%!TEX If using numberless sections we recomend to change the values 
+
+\titlecontents{section}[\tocsep] % \setlength\tocsep{0c}
+    {\addvspace{4pt}\sffamily\selectfont\bfseries}
+    {\contentslabel[\thecontentslabel]{\tocsep}}
+    {}
+    {\hfill\thecontentspage}
+    []
+
+\titlecontents{subsection}[3pc] % 1pc
+    {\addvspace{4pt}\small\sffamily\selectfont}
+    {\contentslabel[\thecontentslabel]{\tocsep}}
+    {}
+    {\ \titlerule*[.5pc]{.}\ \thecontentspage}
+    []
+
+\titlecontents*{subsubsection}[3pc] % 1pc
+    {\footnotesize\sffamily\selectfont}
+    {}
+    {}
+    {}
+    [\ \textbullet\ ]
+
+%----------------------------------------------------------
+% FIGURE-, TABLE-, LISTINGS- CAPTION STYLE
+%----------------------------------------------------------
+
+% General captions
+\RequirePackage[
+    labelfont={bf,sf},
+    list=no,
+    labelsep=period,
+    singlelinecheck=off,
+    font=small,
+    justification=centering
+]{caption}
+
+% Table caption
+\captionsetup[table]{position=below}
+\newcommand{\tabletext}[1]{{\setlength{\leftskip}{9pt}\fontsize{7}{9}\vskip2pt\selectfont#1}}
+
+% Listings caption
+\newcommand{\captioncodelanguage}{
+    \iflanguage{spanish}{
+        {C\'odigo}%
+    }{%
+        {Code}%
+    }%
+}
+\captionsetup[lstlisting]{font=small, labelfont={bf,sf}, belowskip=3pt, position=below, labelsep=period}
+\renewcommand\lstlistingname{\captioncodelanguage}
+\renewcommand\lstlistlistingname{\captioncodelanguage}
+
+%----------------------------------------------------------
+% LISTINGS STYLE
+%----------------------------------------------------------
+
+% Defined colors for listings environment
+\definecolor{rhocodeback}{RGB}{248, 248, 248}  
+% \definecolor{rhocodeback}{RGB}{255, 255, 255}     % Alternative back color
+\definecolor{rhocodecomment}{RGB}{1, 136, 0}
+\definecolor{rhocodekey}{RGB}{53, 53, 128}
+\definecolor{rhocodestring}{RGB}{122, 36, 47}
+\definecolor{rhogray}{RGB}{0.5,0.5,0.5}
+\definecolor{rhoredmatlab}{RGB}{199, 78, 0}
+
+% Rho codes style
+\lstdefinestyle{rhocoding}{
+    backgroundcolor=\color{rhocodeback},   
+    commentstyle=\color{rhocodecomment},
+    keywordstyle=\color{rhocodekey},
+    numberstyle=\tiny\color{rhogray},
+    stringstyle=\color{rhocodestring},
+    breakatwhitespace=false,        
+    basicstyle=\small\ttfamily,
+    breaklines=true,                 
+    captionpos=b,                    
+    keepspaces=true,                 
+    numbers=left,				 	% if "none" change the values  
+    numbersep=8pt,    				% 0pt              
+    showspaces=false,                
+    showstringspaces=false,
+    showtabs=false,                  
+    tabsize=2,
+    aboveskip=12pt,
+    belowskip=8pt,
+    xleftmargin=10pt,				% 0pt
+    rulecolor=\color{rhogray},
+    frame=single
+}
+
+% Matlab
+\lstset{
+    language=Matlab,
+    rulecolor=\color{rhogray},
+    emph=[1]{for,end,break},
+    emphstyle=[1]\color{rhoredmatlab},
+}
+
+\lstset{style=rhocoding}
+
+%----------------------------------------------------------
+% FOOTNOTE STYLE
+%----------------------------------------------------------
+
+\definecolor{black50}{gray}{0.5}
+\renewcommand*{\footnotelayout}{\normalfont\fontsize{6}{8}}
+\renewcommand{\footnoterule}{
+    \kern -3pt
+    {\color{black50} \hrule width 75pt height 0.25pt}
+    \kern 2.5pt
+}
+
+%----------------------------------------------------------
+% BIBLIOGRAPHY
+%----------------------------------------------------------
+% biblatex removed; Pandoc citeproc manages the bibliography.
+\providecommand{\printbibliography}{}
+
+%----------------------------------------------------------
+
+\endinput

--- a/templates/rho/rho-class/rhobabel.sty
+++ b/templates/rho/rho-class/rhobabel.sty
@@ -1,0 +1,123 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+% Rhobabel
+% LaTeX Package
+% Version 1.0.1 (14/08/2024)
+%
+% Authors: 
+% Guillermo Jimenez (memo.notess1@gmail.com)
+% Eduardo Gracidas (eduardo.gracidas29@gmail.com)
+% 
+% License:
+% Creative Commons CC BY 4.0
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+%                        WARNING!
+% --------------------------------------------------------
+% Do not remove this package from 'rho-class/rho.cls' to 
+% avoid compilation problems. This package defines the 
+% translation to spanish for some parts of the text.
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%----------------------------------------------------------
+% PACKAGE CONFIGURATION
+%----------------------------------------------------------
+
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{rho-class/rhobabel}[2024/05/21]
+
+%----------------------------------------------------------
+% KEYWORDS WORD
+%----------------------------------------------------------
+
+\newcommand{\keywordname}{{\keywordheadfont Keywords: }}
+
+%----------------------------------------------------------
+% AUTHOR "AND" LANGUAGES
+%----------------------------------------------------------
+
+\newcommand{\andlanguage}{
+    \iflanguage{spanish}{
+        { y }%
+    }{%
+        { and }%
+    }%
+}
+
+%----------------------------------------------------------
+% ARTICLE INFORMATION LANGUAGES
+%----------------------------------------------------------
+
+% Change manually the second {} if using another language babel
+
+\newcommand{\correslanguage}{
+    \iflanguage{spanish}{
+        {Autor de correspondencia: }%
+    }{%
+        {Corresponding author: }%
+    }%
+}
+
+\newcommand{\emaillanguage}{
+    \iflanguage{spanish}{
+        {Correo electr\'onico: }%
+    }{%
+        {E-mail address: }%
+    }%
+}
+
+\newcommand{\receivedlanguage}{
+    \iflanguage{spanish}{
+        {Recibido: }%
+    }{%
+        {Received: }%
+    }%
+}
+
+\newcommand{\revisedlanguage}{
+    \iflanguage{spanish}{
+        {Revisado: }%
+    }{%
+        {Revised: }%
+    }%
+}
+
+\newcommand{\acceptedlanguage}{
+    \iflanguage{spanish}{
+        {Aceptado: }%
+    }{%
+        {Accepted: }%
+    }%
+}
+
+\newcommand{\publishedlanguage}{
+    \iflanguage{spanish}{
+        {Publicado: }%
+    }{%
+        {Published: }%
+    }%
+}
+
+%----------------------------------------------------------
+% ENVIRONMENTS LANGUAGES
+%----------------------------------------------------------
+
+% Information/Informaci\'on language setup
+\newcommand{\infolanguage}{
+    \iflanguage{spanish}{
+        {\bfseries\noindent Informaci\'on}%
+    }{%
+        {\bfseries\noindent Information}%
+    }%
+}
+
+% Note/Nota language setup
+\newcommand{\notelanguage}{
+    \iflanguage{spanish}{
+        {\bfseries\noindent Nota}%
+    }{%
+        {\bfseries\noindent Note}%
+    }%
+}

--- a/templates/rho/rho-class/rhoenvs.sty
+++ b/templates/rho/rho-class/rhoenvs.sty
@@ -1,0 +1,107 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+% Rhoenvs
+% LaTeX Package
+% Version 1.0.1 (21/05/2024)
+%
+% Authors: 
+% Guillermo Jimenez (memo.notess1@gmail.com)
+% Eduardo Gracidas (eduardo.gracidas29@gmail.com)
+% 
+% License:
+% Creative Commons CC BY 4.0
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% --------------------------------------------------------
+%                        WARNING!
+% --------------------------------------------------------
+% Do not remove this package from 'class/rho.cls' to 
+% avoid compilation problems. This package defines the 
+% included environments and colors.
+% --------------------------------------------------------
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%----------------------------------------------------------
+% PACKAGE CONFIGURATION
+%----------------------------------------------------------
+
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{rho-class/rhoenvs}[2024/05/21]
+
+%----------------------------------------------------------
+% COLORS
+%----------------------------------------------------------
+
+\RequirePackage{xcolor}
+\definecolor{rhocolor}{rgb}{0.0,0.2,0.4}        % Blue
+%\definecolor{rhocolor}{rgb}{0.12, 0.3, 0.17}   % Green
+%\definecolor{rhocolor}{rgb}{0.4, 0.26, 0.13}   % Brown
+
+%----------------------------------------------------------
+% RHOENV-, INFO-, NOTE- ENVIRONMENTS
+%----------------------------------------------------------
+
+% Rhoenv
+\newmdenv[
+    backgroundcolor=rhocolor!22, 					
+    linecolor=rhocolor!22,									
+    linewidth=0.7pt,
+    frametitle=\vskip0pt\bfseries,
+    frametitlerule=false,
+    frametitlefont=\color{rhocolor}\bfseries\sffamily,
+    frametitlealignment=\raggedright,
+    innertopmargin=3pt,
+    innerbottommargin=6pt,
+    innerleftmargin=6pt,
+    innerrightmargin=6pt,
+    font=\selectfont,
+    fontcolor=rhocolor,									
+    frametitleaboveskip=8pt,
+    skipabove=10pt
+]{rhoenv}
+
+%----------------------------------------------------------
+
+% Info
+\newmdenv[
+    backgroundcolor=rhocolor!22, 						
+    linecolor=rhocolor!22,									
+    linewidth=0.7pt,
+    frametitle=\vskip0pt\bfseries\infolanguage,
+    frametitlerule=false,
+    frametitlefont=\color{rhocolor}\bfseries\sffamily,
+    frametitlealignment=\raggedright,
+    innertopmargin=3pt,
+    innerbottommargin=6pt,
+    innerleftmargin=6pt,
+    innerrightmargin=6pt,
+    font=\normalfont,
+    fontcolor=rhocolor,									
+    frametitleaboveskip=3pt,
+    skipabove=10pt
+]{info}
+
+%----------------------------------------------------------
+
+% Note
+\newmdenv[
+    backgroundcolor=rhocolor!22, 						
+    linecolor=rhocolor!22,									
+    linewidth=0.7pt,
+    frametitle=\vskip0pt\bfseries\notelanguage,
+    frametitlerule=false,
+    frametitlefont=\color{rhocolor}\bfseries\sffamily,
+    frametitlealignment=\raggedright,
+    innertopmargin=3pt,
+    innerbottommargin=6pt,
+    innerleftmargin=6pt,
+    innerrightmargin=6pt,
+    font=\normalfont,
+    fontcolor=rhocolor,									
+    frametitleaboveskip=3pt,
+    skipabove=10pt
+]{note}
+
+%----------------------------------------------------------
+
+\endinput

--- a/templates/rho/rho.latex
+++ b/templates/rho/rho.latex
@@ -1,0 +1,174 @@
+% Rho class (v2.1.1) Pandoc bridge template.
+% The cls loads most standard packages internally (graphicx, hyperref,
+% xcolor, amsmath, booktabs, enumitem, caption, listings, xurl, etc.).
+% We add only what Pandoc requires for syntax highlighting and tables.
+
+\documentclass[$for(classoption)$$classoption$$sep$,$endfor$$if(classoption)$$else$9pt,a4paper,twoside$endif$]{rho-class/rho}
+\usepackage[english]{babel}
+
+\setbool{rho-abstract}{$if(abstract)$true$else$false$endif$}
+\setbool{corres-info}{$if(corres)$true$else$$if(email)$true$else$$if(doi)$true$else$false$endif$$endif$$endif$}
+
+% Journal / footer metadata from YAML frontmatter
+$if(journalname)$\journalname{$journalname$}$endif$
+$if(dates)$\dates{$dates$}$endif$
+$if(leadauthor)$\leadauthor{$leadauthor$}$endif$
+$if(footinfo)$\footinfo{$footinfo$}$endif$
+$if(smalltitle)$\smalltitle{$smalltitle$}$endif$
+$if(institution)$\institution{$institution$}$endif$
+$if(theday)$\theday{$theday$}$endif$
+
+\title{$if(title)$$title$$else$Untitled$endif$}
+
+% Structured authors: rho-authors[].name, rho-authors[].superscript
+% plus rho-affiliations[].superscript, rho-affiliations[].text
+$if(rho-authors)$
+$for(rho-authors)$
+\author[$rho-authors.superscript$]{$rho-authors.name$}
+$endfor$
+$for(rho-affiliations)$
+\affil[$rho-affiliations.superscript$]{$rho-affiliations.text$}
+$endfor$
+$elseif(author)$
+$for(author)$
+\author{$author$}
+$endfor$
+$endif$
+
+% Corresponding author section
+$if(corres)$\corres{$corres$}$endif$
+$if(email)$\email{$email$}$endif$
+$if(doi)$\doi{$doi$}$endif$
+$if(received)$\received{$received$}$endif$
+$if(revised)$\revised{$revised$}$endif$
+$if(accepted)$\accepted{$accepted$}$endif$
+$if(published)$\published{$published$}$endif$
+$if(license)$\license{$license$}$endif$
+
+% Abstract and keywords (declared in preamble per rho convention)
+$if(abstract)$
+\begin{abstract}
+$abstract$
+\end{abstract}
+$endif$
+
+$if(keywords)$\keywords{$keywords$}$endif$
+
+% Pandoc longtable in twocolumn: redirect to table float + tabular.
+\usepackage{longtable}
+\makeatletter
+\newcommand{\rho@colspec}{}
+\renewenvironment{longtable}[2][]{%
+  \begin{table}[H]%
+  \centering
+  \gdef\rho@colspec{#2}%
+  \let\rho@origtabularnewline\tabularnewline
+  \def\tabularnewline{%
+    \let\tabularnewline\rho@origtabularnewline
+    \expandafter\tabular\expandafter{\rho@colspec}%
+  }%
+}{%
+  \endtabular
+  \end{table}%
+}
+\def\endfirsthead#1\endhead{}
+\def\endhead{}
+\def\endfoot{}
+\def\endlastfoot{}
+\makeatother
+
+% Pandoc syntax highlighting
+\usepackage{framed}
+\usepackage{fancyvrb}
+\definecolor{shadecolor}{RGB}{248,248,248}
+\newenvironment{Shaded}{\begin{snugshade}}{\end{snugshade}}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
+\newcommand{\AlertTok}[1]{\textcolor[rgb]{0.94,0.16,0.16}{#1}}
+\newcommand{\AnnotationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\AttributeTok}[1]{\textcolor[rgb]{0.77,0.63,0.00}{#1}}
+\newcommand{\BaseNTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
+\newcommand{\BuiltInTok}[1]{#1}
+\newcommand{\CharTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\CommentTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textit{#1}}}
+\newcommand{\CommentVarTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\ConstantTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\ControlFlowTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{\textbf{#1}}}
+\newcommand{\DataTypeTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{#1}}
+\newcommand{\DecValTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
+\newcommand{\DocumentationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\ErrorTok}[1]{\textcolor[rgb]{0.64,0.00,0.00}{\textbf{#1}}}
+\newcommand{\ExtensionTok}[1]{#1}
+\newcommand{\FloatTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
+\newcommand{\FunctionTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\ImportTok}[1]{#1}
+\newcommand{\InformationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{\textbf{#1}}}
+\newcommand{\NormalTok}[1]{#1}
+\newcommand{\OperatorTok}[1]{\textcolor[rgb]{0.81,0.36,0.00}{\textbf{#1}}}
+\newcommand{\OtherTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{#1}}
+\newcommand{\PreprocessorTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textit{#1}}}
+\newcommand{\RegionMarkerTok}[1]{#1}
+\newcommand{\SpecialCharTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\SpecialStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\StringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\VariableTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+
+% Pandoc compatibility
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\makeatletter
+\providecommand\pandocbounded[1]{%
+  \sbox\z@{#1}%
+  \ifdim\wd\z@>\linewidth\resizebox{\linewidth}{!}{#1}\else\usebox\z@\fi
+}
+\makeatother
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\makeatother
+\setkeys{Gin}{width=\maxwidth,keepaspectratio}
+\NewDocumentCommand\citeproctext{}{}
+\NewDocumentCommand\citeproc{mm}{%
+  \begingroup\def\citeproctext{#2}\cite{#1}\endgroup}
+\makeatletter
+ \let\@cite@ofmt\@firstofone
+ \def\@biblabel#1{}
+ \def\@cite#1#2{{#1\if@tempswa , #2\fi}}
+\makeatother
+\newlength{\cslhangindent}\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2]%
+ {\begin{list}{}{%
+  \setlength{\itemindent}{0pt}%
+  \setlength{\leftmargin}{0pt}%
+  \setlength{\parsep}{0pt}%
+  \ifodd #1
+   \setlength{\leftmargin}{\cslhangindent}%
+   \setlength{\itemindent}{-1\cslhangindent}%
+  \fi
+  \setlength{\itemsep}{#2\baselineskip}}}
+ {\end{list}}
+\newcommand{\CSLBlock}[1]{\hfill\break\parbox[t]{\linewidth}{\strut\ignorespaces#1\strut}}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{\strut#1\strut}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{\strut#1\strut}}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+\makeatletter
+\@ifundefined{c@none}{\newcounter{none}}{}
+\makeatother
+
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+\begin{document}
+
+\maketitle
+\thispagestyle{firststyle}
+
+$if(toc)$\tableofcontents$endif$
+$if(lof)$\listoffigures$endif$
+$if(lot)$\listoftables$endif$
+
+$body$
+
+\end{document}

--- a/templates/rho/template.json
+++ b/templates/rho/template.json
@@ -1,0 +1,6 @@
+{
+  "name": "Rho Academic Article",
+  "description": "Rho class (v2.1.1) two-column academic article. Set journalname, rho-authors, rho-affiliations, dates, corres, email, doi, received, revised, accepted, published, license, leadauthor, footinfo, smalltitle, institution, theday, keywords in YAML frontmatter.",
+  "documentclass": "rho",
+  "engine": "pdflatex"
+}


### PR DESCRIPTION
## Summary
- Adds the Rho class (v2.1.1, CC BY 4.0) as a built-in template with two-column academic article layout, colored section headers, styled abstract box, and corresponding-author metadata
- Pandoc bridge template maps all YAML frontmatter fields (journalname, rho-authors/affiliations, dates, corres, email, doi, received/revised/accepted/published, license, footer fields, keywords)
- Strips biblatex/biber from the class and uses citeproc for bibliography, matching the existing pipeline
- Includes `examples/demo-rho.md` that compiles cleanly with zero warnings

Closes #5

## Test plan
- [x] `demo-rho.md` compiles to PDF via Pandoc + pdflatex with zero errors
- [x] Cross-references (equations, tables) resolve with pandoc-crossref
- [x] Bibliography citation renders via citeproc
- [x] Two-column layout, abstract box, author/affiliation block, footer metadata all appear correctly
- [ ] Manual test: reload extension, open `demo-rho.md`, verify Rho appears in template picker
- [ ] Verify existing templates (inkwell, ludus, tmsce, rmxaa) still compile without regression