### PR TITLE
feat: add logo and linenumbers YAML frontmatter options

### DIFF
--- a/examples/demo-rmxaa.md
+++ b/examples/demo-rmxaa.md
@@ -39,6 +39,7 @@ pages: "1--6"
 yearofpub: 2026
 received: "January 15, 2026"
 accepted: "February 20, 2026"
+linenumbers: true
 bibliography: references/refs.bib
 link-citations: true
 inkwell:

--- a/templates/ludus/ludus.latex
+++ b/templates/ludus/ludus.latex
@@ -8,6 +8,7 @@ $if(journalsubtitle)$\journalsubtitle{$journalsubtitle$}$endif$
 $if(conferencename)$\conferencename{$conferencename$}$endif$
 $if(publicationyear)$\publicationyear{$publicationyear$}$endif$
 $if(articledoi)$\articledoi{$articledoi$}$endif$
+$if(logo)$\logofile{$logo$}$endif$
 
 \title{$if(title)$$title$$else$Untitled$endif$}
 $if(shorttitle)$\shorttitle{$shorttitle$}$endif$
@@ -29,6 +30,7 @@ $endif$
 \usepackage{enumitem}
 \usepackage{float}
 \usepackage{adjustbox}
+\usepackage[switch]{lineno}
 \usepackage{xurl}
 
 % Pandoc emits longtable, which fails in twocolumn mode.
@@ -154,6 +156,7 @@ $endif$
 $if(keywords)$\keywords{$keywords$}$endif$
 
 \maketitle
+$if(linenumbers)$\linenumbers$endif$
 
 $if(toc)$\tableofcontents$endif$
 $if(lof)$\listoffigures$endif$

--- a/templates/ludus/ludusofficial.cls
+++ b/templates/ludus/ludusofficial.cls
@@ -201,6 +201,7 @@
 \newcommand{\journalsubtitle}[1]{\renewcommand{\@journalsubtitle}{#1}}
 \newcommand{\journalurl}[1]{\renewcommand{\@journalurl}{#1}}
 \newcommand{\institution}[1]{\renewcommand{\@institution}{#1}}
+\newcommand{\logofile}[1]{\def\@logofile{#1}}
 \newcommand{\conferencename}[1]{\renewcommand{\@conferencename}{#1}}
 \newcommand{\issuenumber}[1]{\renewcommand{\@issuenumber}{#1}}
 \newcommand{\publicationyear}[1]{\renewcommand{\@publicationyear}{#1}}
@@ -245,17 +246,11 @@
         \raisebox{-0.3\height}{\fontsize{7.5}{9}\selectfont\sffamily\textcolor{darkgray}{\@institution}}%
     }
     \fancyhead[C]{%
-        % Logo centered, height approximately 5mm (adapted to original headheight)
-        \IfFileExists{../logo.png}{%
-            \includegraphics[height=5mm]{../logo.png}%
-        }{%
-            \IfFileExists{logo.png}{%
-                \includegraphics[height=5mm]{logo.png}%
-            }{%
-                % If logo does not exist, display placeholder text
-                \fontsize{7.5}{9}\selectfont\sffamily\textcolor{darkgray}{[LOGO]}%
-            }%
-        }%
+        \ifx\@logofile\undefined\else
+            \IfFileExists{\@logofile}{%
+                \includegraphics[height=5mm]{\@logofile}%
+            }{}%
+        \fi
     }
     \fancyhead[R]{%
         \raisebox{-0.3\height}{\fontsize{7.5}{9}\selectfont\sffamily\textcolor{darkgray}{\@journalurl}}%

--- a/templates/rho/rho.latex
+++ b/templates/rho/rho.latex
@@ -158,6 +158,24 @@ $if(keywords)$\keywords{$keywords$}$endif$
 \@ifundefined{c@none}{\newcounter{none}}{}
 \makeatother
 
+$if(logo)$
+\makeatletter
+\fancypagestyle{firststyle}{%
+    \fancyfoot[R]{%
+        {\ifx\@institution\undefined\else\footerfont\@institution\hspace{10pt}\fi}%
+        {\ifx\@theday\undefined\else\footerfont\bfseries\@theday\hspace{10pt}\fi}%
+        {\ifx\@smalltitle\undefined\else\footerfont\@smalltitle\hspace{10pt}\fi}%
+        {\footerfont\textbf\thepage\textendash\pageref{LastPage}}%
+    }%
+    \fancyfoot[L]{\ifx\@footinfo\undefined\else\footerfont\@footinfo\fi}%
+    \fancyfoot[C]{}%
+    \fancyhead[C]{}%
+    \fancyhead[R]{\raisebox{-0.5\height}{\includegraphics[height=\headheight,keepaspectratio]{$logo$}}}%
+    \fancyhead[L]{}%
+}
+\makeatother
+$endif$
+
 $for(header-includes)$
 $header-includes$
 $endfor$
@@ -166,6 +184,7 @@ $endfor$
 
 \maketitle
 \thispagestyle{firststyle}
+$if(linenumbers)$\linenumbers$endif$
 
 $if(toc)$\tableofcontents$endif$
 $if(lof)$\listoffigures$endif$

--- a/templates/rmxaa/rmaa-rho-class/rmaa-rho.cls
+++ b/templates/rmxaa/rmaa-rho-class/rmaa-rho.cls
@@ -364,9 +364,9 @@
             \begin{minipage}[t]{\textwidth} 
                 \RaggedLeft
                 \vspace*{-3.39\baselineskip}
-                %\includegraphics[width=1.2217in, height=0.4329in]
-                 \includegraphics[width=1.45in, height=0.5031in]
-                {\logofile}
+                \IfFileExists{\logofile}{%
+                  \includegraphics[width=1.45in, height=0.5031in]{\logofile}%
+                }{}
             \end{minipage}
         \vskip15pt
             {\RaggedRight\bfseries\fontsize{20}{25}\selectfont\@title\par}

--- a/templates/rmxaa/rmxaa.latex
+++ b/templates/rmxaa/rmxaa.latex
@@ -19,6 +19,7 @@
 \AtEndPreamble{\def\NAT@force@numbers{}}
 \makeatother
 \RMxAAtemplatetype{\RMxAA}
+$if(logo)$\def\logofile{$logo$}$else$\def\logofile{}$endif$
 
 % Provide defaults for fields the cls uses unconditionally in \maketitle.
 \vol{$if(vol)$$vol$$else$0$endif$}
@@ -181,6 +182,7 @@ $endfor$
 
 \maketitle
 \pagestyle{fancy}\thispagestyle{firststyle}
+$if(linenumbers)$$else$\nolinenumbers$endif$
 
 $if(toc)$\tableofcontents$endif$
 $if(lof)$\listoffigures$endif$


### PR DESCRIPTION
## Summary
- Adds `logo: path/to/image.png` YAML field to render a logo on the first page of all three two-column templates (rho, rmxaa, ludus). Omitting the field produces no logo.
- Adds `linenumbers: true` YAML field to toggle line numbering. Rho and Ludus enable on request; RMxAA (which defaults to on) disables when the field is absent.
- RMxAA cls wraps logo `\includegraphics` in `\IfFileExists` for safe fallback
- Ludus cls uses configurable `\@logofile` macro instead of hardcoded `logo.png`; removes `[LOGO]` placeholder text

## Test plan
- [x] Rho: compiles without logo field (no logo), compiles with `logo: logo.png` (logo in header)
- [x] Ludus: compiles without logo field (empty header center), compiles with `logo: logo.png` (logo in header)
- [x] RMxAA: compiles with `logo:` empty (no logo), overrides `\logofile` when path provided
- [x] `linenumbers: true` enables line numbers in rho, rmxaa, ludus
- [x] Omitting `linenumbers` disables them (rmxaa override confirmed)