### PR TITLE
fix: remove hardcoded linenumbers from rmaa-rho.cls

### DIFF
--- a/examples/demo-rmxaa.md
+++ b/examples/demo-rmxaa.md
@@ -39,7 +39,7 @@ pages: "1--6"
 yearofpub: 2026
 received: "January 15, 2026"
 accepted: "February 20, 2026"
-linenumbers: true
+linenumbers: false
 bibliography: references/refs.bib
 link-citations: true
 inkwell:

--- a/templates/rmxaa/rmaa-rho-class/rmaa-rho.cls
+++ b/templates/rmxaa/rmaa-rho-class/rmaa-rho.cls
@@ -31,7 +31,7 @@
 \let\oldtablenotetext\tablenotetext
 
 % --- Continúa con el resto de paquetes ---
-\AtBeginDocument{\linenumbers}
+% \AtBeginDocument{\linenumbers}  % controlled by template via YAML frontmatter
 \AtEndOfClass{\let\CheckCommand\providecommand\RequirePackage{microtype}}
 
 %----------------------------------------------------------

--- a/templates/rmxaa/rmxaa.latex
+++ b/templates/rmxaa/rmxaa.latex
@@ -179,7 +179,7 @@ $header-includes$
 $endfor$
 
 \begin{document}
-$if(linenumbers)$$else$\nolinenumbers$endif$
+$if(linenumbers)$\linenumbers$endif$
 
 \maketitle
 \pagestyle{fancy}\thispagestyle{firststyle}


### PR DESCRIPTION
## Summary
- Removed `\AtBeginDocument{\linenumbers}` from `rmaa-rho.cls`, which was unconditionally enabling line numbers and overriding the template's `\nolinenumbers`.
- Changed the template from opt-out (`\nolinenumbers` when false) to opt-in (`\linenumbers` when true). Line numbers now only appear when `linenumbers: true` is set in YAML frontmatter.
- Updated `demo-rmxaa.md` to `linenumbers: false` to demonstrate the toggle.

## Test plan
- [ ] Compile `demo-rmxaa.md` with `linenumbers: false`, verify no line numbers
- [ ] Change to `linenumbers: true`, recompile, verify line numbers appear
- [ ] Remove `linenumbers` key entirely, verify no line numbers (opt-in default)