### PR TITLE
docs: add commented header-includes hint to demo files

### DIFF
--- a/examples/demo-default.md
+++ b/examples/demo-default.md
@@ -7,6 +7,9 @@ geometry: "margin=1in"
 toc: true
 lof: true
 lot: true
+# header-includes: |
+#   \usepackage{xcolor}
+#   \setlength{\parindent}{0pt}
 bibliography: references/refs.bib
 link-citations: true
 inkwell:

--- a/examples/demo-ludus.md
+++ b/examples/demo-ludus.md
@@ -31,6 +31,9 @@ abstract: |
 keywords: "literate programming; reproducible research; Pandoc; LaTeX"
 acknowledgments: |
   The authors thank the Inkwell contributors for the template system.
+# header-includes: |
+#   \usepackage{xcolor}
+#   \setlength{\parindent}{0pt}
 bibliography: references/refs.bib
 link-citations: true
 figPrefix: "figure"

--- a/examples/demo-rho.md
+++ b/examples/demo-rho.md
@@ -40,6 +40,9 @@ abstract: |
   corresponding-author metadata, and footer fields. All of these are
   controlled from YAML frontmatter: no LaTeX editing required.
 keywords: "Inkwell, Pandoc, Rho class, academic template, reproducible documents"
+# header-includes: |
+#   \usepackage{xcolor}
+#   \setlength{\parindent}{0pt}
 bibliography: references/refs.bib
 link-citations: true
 figPrefix: "figure"

--- a/examples/demo-rmxaa.md
+++ b/examples/demo-rmxaa.md
@@ -40,6 +40,9 @@ yearofpub: 2026
 received: "January 15, 2026"
 accepted: "February 20, 2026"
 linenumbers: false
+# header-includes: |
+#   \usepackage{xcolor}
+#   \setlength{\parindent}{0pt}
 bibliography: references/refs.bib
 link-citations: true
 inkwell:


### PR DESCRIPTION
## Summary
- Added a commented-out `header-includes` block to all four demo files (default, ludus, rho, rmxaa) showing users how to inject custom LaTeX packages and settings via YAML frontmatter.

## Test plan
- [ ] Verify demo files compile without errors (comments are inert)
- [ ] Uncomment the block in one file, confirm the packages load