### PR TITLE
feat: add inline data binding with variable store and expressions

### DIFF
--- a/examples/demo-default.md
+++ b/examples/demo-default.md
@@ -63,8 +63,14 @@ fig.tight_layout()
 fig.savefig(os.path.join(os.environ.get("INKWELL_OUTPUT_DIR", "."),
             "scatter.png"), dpi=200, bbox_inches="tight")
 plt.close(fig)
-print(f"n = {len(x)}, r = {np.corrcoef(x, y)[0,1]:.3f}")
+r_val = np.corrcoef(x, y)[0, 1]
+print(f"n = {len(x)}, r = {r_val:.3f}")
+print(f"::inkwell scatter_n={len(x)}")
+print(f"::inkwell scatter_r={r_val:.3f}")
+print(f"::inkwell scatter_slope={m:.3f}")
 ```
+
+The regression was fitted to {{scatter_n}} observations, yielding a Pearson correlation of $r = `{python} f"{float(scatter_r):.2f}"`$ and estimated slope $\hat\beta = {{scatter_slope}}$.
 
 ## Tables
 

--- a/examples/demo-ludus.md
+++ b/examples/demo-ludus.md
@@ -39,18 +39,19 @@ link-citations: true
 figPrefix: "figure"
 tblPrefix: "table"
 eqnPrefix: "equation"
+secPrefix: "section"
 inkwell:
   code-display: output
   python-env: ./venv
 ---
 
-# Introduction
+# Introduction {#sec:intro}
 
 Academic publishing requires precise formatting that varies by journal. Inkwell addresses this by compiling markdown to journal-specific LaTeX classes through Pandoc [@macfarlane2023]. This document uses the Ludus Academik template, producing a two-column layout with themed section headers.
 
 The literate programming paradigm [@knuth1984] allows code and prose to coexist. Inkwell extends this to compiled PDF output: code blocks execute, and their results (figures, tables, text) appear in the final document.
 
-# Computational Example
+# Computational Example {#sec:computation}
 
 We demonstrate with a Fourier series visualization [@fourier1822]. The partial sum approximating a square wave is given by @eq:fourier.
 
@@ -61,14 +62,14 @@ $$f_n(x) = \sum_{k=1}^{n} \frac{4}{(2k-1)\pi}\sin\bigl((2k-1)x\bigr)$$ {#eq:four
 ```{python file="scripts/sine_plot.py" output="sine_plot" caption="Fourier partial sums converging to a square wave." label="fourier"}
 ```
 
-# Data Visualization
+# Data Visualization {#sec:dataviz}
 
 @Fig:scatter shows a simulated scatter plot with linear regression, generated inline by Python.
 
 ```{python file="scripts/scatter.py" output="scatter" caption="Simulated regression with n = 150 data points." label="scatter"}
 ```
 
-# Results
+# Results {#sec:results}
 
 @Tbl:convergence shows the convergence behavior of the Fourier partial sums at the midpoint $x = \pi/2$, where the true value is $f(x) = 1$. The peak overshoot column quantifies the Gibbs phenomenon: regardless of $n$, the maximum value overshoots by approximately 9% of the jump magnitude.
 
@@ -77,6 +78,6 @@ $$f_n(x) = \sum_{k=1}^{n} \frac{4}{(2k-1)\pi}\sin\bigl((2k-1)x\bigr)$$ {#eq:four
 
 # Conclusion
 
-As shown in @Fig:fourier and @Fig:scatter, Inkwell produces publication-quality figures from Python scripts. @Tbl:convergence demonstrates CSV-to-table rendering, and @Eq:fourier confirms that LaTeX math compiles correctly. The Ludus template handles all of these in a two-column layout with themed headers and bibliography.
+The regression in @Fig:scatter was fitted to $n = {{sample_n}}$ observations, yielding $r = {{corr_r}}$ and $\hat\beta = `{python} f"{float(slope):.2f}"`$. As shown in @Fig:fourier and @Fig:scatter, Inkwell produces publication-quality figures from Python scripts. @Tbl:convergence in @sec:results demonstrates CSV-to-table rendering, and @Eq:fourier in @sec:computation confirms that LaTeX math compiles correctly. The Ludus template handles all of these in a two-column layout with themed headers and bibliography.
 
 ## References

--- a/examples/demo-rho.md
+++ b/examples/demo-rho.md
@@ -48,15 +48,16 @@ link-citations: true
 figPrefix: "figure"
 tblPrefix: "table"
 eqnPrefix: "equation"
+secPrefix: "section"
 ---
 
-# Introduction
+# Introduction {#sec:intro}
 
 The Rho LaTeX class provides a polished two-column layout for academic articles and lab reports. Originally designed for Overleaf, it is adapted here as an Inkwell template so that authors can write in markdown and produce publication-quality PDFs.
 
 Rho's visual identity includes colored section headers, a tinted abstract box with keywords, and a corresponding-author block with dates, DOI, and license. All metadata is set in the YAML frontmatter above.
 
-# Equations
+# Equations {#sec:equations}
 
 The Schrodinger equation serves as a typesetting example:
 
@@ -64,7 +65,7 @@ $$\frac{\hbar^2}{2m}\nabla^2\Psi + V(\mathbf{r})\Psi = -i\hbar \frac{\partial\Ps
 
 @Eq:schrodinger renders through Pandoc's `tex_math_dollars` extension. The `stix2` font bundled with Rho provides high-quality mathematical symbols without additional packages.
 
-# Code Highlighting
+# Code Highlighting {#sec:code}
 
 Pandoc syntax highlighting works alongside Rho's built-in listings style. Fenced code blocks produce colored output:
 
@@ -79,7 +80,7 @@ def fourier_partial_sum(x, n_terms):
     return result
 ```
 
-# Tables
+# Tables {#sec:tables}
 
 Pandoc pipe tables compile into single-column table floats. Rho's caption style applies automatically.
 
@@ -91,9 +92,9 @@ Pandoc pipe tables compile into single-column table floats. Rho's caption style 
 
 : Weekly forecast example. {#tbl:forecast}
 
-# Cross-References
+# Cross-References {#sec:crossref}
 
-Pandoc-crossref handles numbered references: @Eq:schrodinger for equations, @Tbl:forecast for tables. Section numbers, figure labels, and bibliography citations [@macfarlane2023] all resolve in the compiled output.
+Pandoc-crossref handles numbered references: @Eq:schrodinger for equations, @Tbl:forecast for tables, and @sec:equations or @sec:tables for sections. Bibliography citations [@macfarlane2023] also resolve in the compiled output. As discussed in @sec:intro, all metadata is controlled from YAML frontmatter.
 
 # Conclusion
 

--- a/examples/demo-rmxaa.md
+++ b/examples/demo-rmxaa.md
@@ -45,18 +45,22 @@ linenumbers: false
 #   \setlength{\parindent}{0pt}
 bibliography: references/refs.bib
 link-citations: true
+figPrefix: "figure"
+tblPrefix: "table"
+eqnPrefix: "equation"
+secPrefix: "section"
 inkwell:
   code-display: output
   python-env: ./venv
 ---
 
-# INTRODUCTION
+# INTRODUCTION {#sec:intro}
 
 Stellar light curve analysis often requires decomposing periodic signals into frequency components. The Fourier series provides the mathematical framework for this decomposition [@fourier1822], and modern computational tools allow rapid visualization of convergence properties.
 
 This document demonstrates the RMxAA journal template compiled from markdown through Pandoc [@macfarlane2023] and LaTeX. Code blocks execute in place, producing figures that appear in the compiled PDF.
 
-# FOURIER ANALYSIS
+# FOURIER ANALYSIS {#sec:fourier}
 
 The partial sum of a square wave's Fourier series is
 
@@ -69,7 +73,7 @@ Figure 1 shows the convergence for increasing $n$.
 ```{python file="scripts/sine_plot.py" output="sine_plot" caption="Fourier partial sums for n = 1, 3, 5, 9."}
 ```
 
-# DATA EXAMPLE
+# DATA EXAMPLE {#sec:data}
 
 A simulated regression demonstrates inline code execution:
 
@@ -88,6 +92,6 @@ A simulated regression demonstrates inline code execution:
 
 # CONCLUSION
 
-The RMxAA template compiles from markdown with the journal's native two-column layout, dual-language abstracts, and standard bibliography formatting. Inkwell's code blocks produce embedded figures without manual export steps, following the literate programming paradigm [@knuth1984].
+The RMxAA template compiles from markdown with the journal's native two-column layout, dual-language abstracts, and standard bibliography formatting. As demonstrated in @sec:fourier and @sec:data, Inkwell's code blocks produce embedded figures without manual export steps, following the literate programming paradigm [@knuth1984].
 
 ## References

--- a/examples/scripts/scatter.py
+++ b/examples/scripts/scatter.py
@@ -26,3 +26,8 @@ plt.close(fig)
 
 r = np.corrcoef(x, y)[0, 1]
 print(f"n = {len(x)}, r = {r:.3f}, slope = {m:.3f}")
+
+print(f"::inkwell sample_n={len(x)}")
+print(f"::inkwell corr_r={r:.3f}")
+print(f"::inkwell slope={m:.3f}")
+print(f"::inkwell intercept={b:.3f}")

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -2,10 +2,18 @@
 // markdown with their cached outputs (stdout, images, tables) prior to
 // compilation or preview rendering. The display mode per block controls
 // whether the reader sees code, output, both, or nothing.
+//
+// Also handles inline data binding:
+//   - Variable store: code blocks export values via print("::inkwell key=val")
+//     or a vars.json artifact. Referenced with {{key}} in markdown.
+//   - Inline expressions: `{python} expr` backtick spans are batch-evaluated
+//     in a Python process with the variable store pre-loaded.
 
 import * as path from "path";
 import * as fs from "fs";
-import { BlockResult, CodeBlock, DisplayMode, parseCodeBlocks, parseRunConfig } from "./runner";
+import * as crypto from "crypto";
+import { execFileSync } from "child_process";
+import { BlockResult, CodeBlock, DisplayMode, parseCodeBlocks, parseRunConfig, RunConfig } from "./runner";
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".svg", ".pdf", ".eps"]);
 
@@ -15,8 +23,56 @@ const PANDOC_LANG_MAP: Record<string, string> = {
   zsh: "bash",
 };
 
+const INKWELL_VAR_RE = /^::inkwell\s+(\w+)=(.+)$/;
+
 function resolveDisplay(block: CodeBlock, defaultDisplay: DisplayMode): DisplayMode {
   return block.display || defaultDisplay;
+}
+
+// ── Layer 1: Variable store ───────────────────────────────────────────
+
+export function collectVariables(results: BlockResult[]): Map<string, string> {
+  const vars = new Map<string, string>();
+
+  for (const r of results) {
+    if (r.exitCode !== 0) continue;
+
+    for (const line of r.stdout.split("\n")) {
+      const m = INKWELL_VAR_RE.exec(line.trim());
+      if (m) vars.set(m[1], m[2]);
+    }
+
+    const varsJson = r.artifacts.get("vars");
+    if (varsJson && path.extname(varsJson).toLowerCase() === ".json") {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(varsJson, "utf-8"));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          for (const [k, v] of Object.entries(parsed)) {
+            vars.set(k, String(v));
+          }
+        }
+      } catch {}
+    }
+  }
+
+  return vars;
+}
+
+export function stripInkwellLines(stdout: string): string {
+  return stdout
+    .split("\n")
+    .filter((line) => !INKWELL_VAR_RE.test(line.trim()))
+    .join("\n");
+}
+
+export function substituteVariables(
+  markdown: string,
+  vars: Map<string, string>,
+): string {
+  if (!vars.size) return markdown;
+  return markdown.replace(/\{\{(\w+)\}\}/g, (_match, key) => {
+    return vars.get(key) ?? `{{${key}}}`;
+  });
 }
 
 export function injectResults(
@@ -102,13 +158,14 @@ function buildOutputContent(result: BlockResult): string | null {
   const parts: string[] = [];
   const caption = result.block.caption;
   const label = result.block.label;
+  const stdout = stripInkwellLines(result.stdout);
 
   if (result.block.output) {
     const artifact = result.artifacts.get(result.block.output);
     if (artifact) {
       parts.push(formatArtifact(result.block.output, artifact, caption, label));
-    } else if (result.stdout.trim()) {
-      const text = result.stdout.trim();
+    } else if (stdout.trim()) {
+      const text = stdout.trim();
       if (looksLikeMarkdown(text)) {
         parts.push(text);
       } else {
@@ -122,8 +179,8 @@ function buildOutputContent(result: BlockResult): string | null {
     parts.push(formatArtifact(name, filepath, caption, label));
   }
 
-  if (result.stdout.trim()) {
-    const text = result.stdout.trim();
+  if (stdout.trim()) {
+    const text = stdout.trim();
     if (looksLikeMarkdown(text)) {
       parts.push(text);
     } else {
@@ -278,20 +335,142 @@ export function gatherCachedResults(
   return results;
 }
 
+// ── Layer 2: Inline expressions ───────────────────────────────────────
+
+const INLINE_EXPR_RE = /`\{python\}\s+([^`]+)`/g;
+
+function resolvePython(runConfig: RunConfig, workDir: string): string {
+  const envSpec = runConfig.pythonEnv;
+  if (envSpec) {
+    const resolved = path.resolve(workDir, envSpec.replace(/^~/, process.env.HOME || "~"));
+    for (const bin of ["bin/python3", "bin/python"]) {
+      const full = path.join(resolved, bin);
+      if (fs.existsSync(full)) return full;
+    }
+  }
+  return "python3";
+}
+
+export function evaluateInlineExpressions(
+  markdown: string,
+  vars: Map<string, string>,
+  runConfig: RunConfig,
+  workDir: string,
+  cacheDir: string,
+): string {
+  const matches: { full: string; expr: string }[] = [];
+  let m: RegExpExecArray | null;
+  const re = new RegExp(INLINE_EXPR_RE.source, "g");
+  while ((m = re.exec(markdown)) !== null) {
+    matches.push({ full: m[0], expr: m[1].trim() });
+  }
+  if (!matches.length) return markdown;
+
+  const exprs = matches.map((e) => e.expr);
+
+  const h = crypto.createHash("sha256");
+  h.update(JSON.stringify(exprs));
+  for (const [k, v] of vars) h.update(`\0${k}=${v}`);
+  const hash = h.digest("hex").substring(0, 16);
+
+  const evalDir = path.join(cacheDir, "inline_eval");
+  fs.mkdirSync(evalDir, { recursive: true });
+  const cachePath = path.join(evalDir, "cache.json");
+
+  try {
+    const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8"));
+    if (cached.hash === hash && Array.isArray(cached.values) && cached.values.length === exprs.length) {
+      return applyInlineResults(markdown, matches, cached.values);
+    }
+  } catch {}
+
+  const lines: string[] = [];
+  for (const [k, v] of vars) {
+    lines.push(`${k} = ${JSON.stringify(v)}`);
+    const num = Number(v);
+    if (!isNaN(num) && v.trim() !== "") {
+      lines.push(`try:\n    ${k} = type(${JSON.stringify(v)})(${num})\nexcept:\n    pass`);
+    }
+  }
+  lines.push("");
+  for (let i = 0; i < exprs.length; i++) {
+    lines.push(`try:`);
+    lines.push(`    __r = ${exprs[i]}`);
+    lines.push(`    print(f"::result_${i}={__r}")`);
+    lines.push(`except Exception as __e:`);
+    lines.push(`    print(f"::result_${i}=??({__e})")`);
+  }
+
+  const script = lines.join("\n");
+  const scriptPath = path.join(evalDir, "eval.py");
+  fs.writeFileSync(scriptPath, script, "utf-8");
+
+  const python = resolvePython(runConfig, workDir);
+
+  let stdout: string;
+  try {
+    stdout = execFileSync(python, ["-u", scriptPath], {
+      cwd: workDir,
+      timeout: 30_000,
+      encoding: "utf-8",
+      env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
+    });
+  } catch {
+    return markdown;
+  }
+
+  const values: string[] = new Array(exprs.length).fill("??");
+  for (const line of stdout.split("\n")) {
+    const rm = /^::result_(\d+)=(.+)$/.exec(line.trim());
+    if (rm) {
+      const idx = parseInt(rm[1], 10);
+      if (idx >= 0 && idx < values.length) values[idx] = rm[2];
+    }
+  }
+
+  try {
+    fs.writeFileSync(cachePath, JSON.stringify({ hash, values }), "utf-8");
+  } catch {}
+
+  return applyInlineResults(markdown, matches, values);
+}
+
+function applyInlineResults(
+  markdown: string,
+  matches: { full: string; expr: string }[],
+  values: string[],
+): string {
+  let result = markdown;
+  for (let i = 0; i < matches.length; i++) {
+    result = result.replace(matches[i].full, values[i]);
+  }
+  return result;
+}
+
 export function prepareForCompilation(
   markdown: string,
   sourceFile: string,
 ): { injected: string; tempFile: string } {
   const workDir = path.dirname(sourceFile);
   const blocks = parseCodeBlocks(markdown);
-  if (!blocks.length) {
+  const hasBlocks = blocks.length > 0;
+  const hasVarRefs = /\{\{\w+\}\}/.test(markdown);
+  const hasInlineExprs = /`\{python\}\s+[^`]+`/.test(markdown);
+
+  if (!hasBlocks && !hasVarRefs && !hasInlineExprs) {
     return { injected: markdown, tempFile: sourceFile };
   }
 
   const runConfig = parseRunConfig(markdown);
   const defaultDisplay = runConfig.defaultDisplay || "output";
   const results = gatherCachedResults(markdown, sourceFile);
-  const injected = injectResults(markdown, results, defaultDisplay, workDir);
+  const vars = collectVariables(results);
+
+  let injected = injectResults(markdown, results, defaultDisplay, workDir);
+  injected = substituteVariables(injected, vars);
+
+  const cacheDir = path.join(workDir, ".inkwell", "outputs");
+  injected = evaluateInlineExpressions(injected, vars, runConfig, workDir, cacheDir);
 
   const ext = path.extname(sourceFile);
   const tempFile = path.join(workDir, ".inkwell", `compiled${ext}`);
@@ -306,11 +485,23 @@ export function prepareForPreview(
   sourceFile: string,
 ): string {
   const blocks = parseCodeBlocks(markdown);
-  if (!blocks.length) return markdown;
+  const hasBlocks = blocks.length > 0;
+  const hasVarRefs = /\{\{\w+\}\}/.test(markdown);
+  const hasInlineExprs = /`\{python\}\s+[^`]+`/.test(markdown);
+
+  if (!hasBlocks && !hasVarRefs && !hasInlineExprs) return markdown;
 
   const workDir = path.dirname(sourceFile);
   const runConfig = parseRunConfig(markdown);
   const defaultDisplay = runConfig.defaultDisplay || "both";
   const results = gatherCachedResults(markdown, sourceFile);
-  return injectResults(markdown, results, defaultDisplay, workDir);
+  const vars = collectVariables(results);
+
+  let injected = injectResults(markdown, results, defaultDisplay, workDir);
+  injected = substituteVariables(injected, vars);
+
+  const cacheDir = path.join(workDir, ".inkwell", "outputs");
+  injected = evaluateInlineExpressions(injected, vars, runConfig, workDir, cacheDir);
+
+  return injected;
 }


### PR DESCRIPTION
## Summary
- **Variable store**: code blocks export values with `print("::inkwell key=val")` or a `vars.json` artifact. Referenced anywhere in markdown with `{{key}}` syntax. Lines are stripped from rendered output.
- **Inline expressions**: `` `{python} expr` `` backtick spans are batch-evaluated in a Python process with the variable store pre-loaded. Results are cached by content hash for fast re-renders.
- Both mechanisms work in prose, captions, table cells, and math environments.
- Added `::inkwell` exports to `scripts/scatter.py` and usage examples in `demo-default.md` and `demo-ludus.md`.
- Added `secPrefix` and section cross-reference labels (`{#sec:label}`, `@sec:label`) to `demo-rho.md`, `demo-ludus.md`, and `demo-rmxaa.md`.

## Test plan
- [ ] Run demo-default.md, verify `{{scatter_n}}` resolves to 150 in the compiled output
- [ ] Verify `` `{python} f"{float(scatter_r):.2f}"` `` evaluates to 0.89 in demo-default.md
- [ ] Run demo-ludus.md, verify inline values appear in the Conclusion section
- [ ] Verify `::inkwell` lines do not appear in rendered code output
- [ ] Change a variable value in scatter.py, rerun, confirm inline values update
- [ ] Verify section cross-references render as numbered links (e.g., "section 2")