### PR TITLE
feat: support mermaid diagrams in compiled PDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ tlmgr install mdframed zref needspace
 
 The Inkwell build log (`Cmd+Shift+U` > **Inkwell LaTeX**) shows the exact missing filename.
 
+**Mermaid diagrams** (optional, for `{mermaid}` code blocks in PDF):
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+brew install librsvg    # macOS; Debian/Ubuntu: sudo apt install librsvg2-bin
+```
+
+`mmdc` renders diagrams to SVG; `librsvg` provides `rsvg-convert` so Pandoc can embed SVGs in LaTeX PDFs. Without these, mermaid blocks still render in the live preview (client-side) but appear as code listings in compiled PDFs.
+
 **Python** (optional, for runnable code blocks):
 
 ```bash
@@ -229,6 +238,23 @@ $\hat\beta = `{python} f"{float(slope):.1f}"`$.
 ```
 
 Re-run the code blocks (`Cmd+Shift+B`) after adding or changing `::inkwell` exports so the variable store picks up the new values.
+
+### Mermaid diagrams
+
+Fenced mermaid blocks compile to SVG figures with full cross-reference support. The preview panel renders them client-side; PDF compilation uses `mmdc` (mermaid-cli) to produce SVGs that Pandoc embeds in the LaTeX output.
+
+````markdown
+```{mermaid caption="System architecture" label="arch"}
+graph LR
+    A[Client] --> B[API Gateway]
+    B --> C[Service]
+    C --> D[Database]
+```
+````
+
+Plain ` ```mermaid ` blocks (without attributes) also render, but without captions or labels. Rendered SVGs are cached in `.inkwell/mermaid/` by content hash.
+
+**Requirements:** `npm install -g @mermaid-js/mermaid-cli` for PDF compilation. For SVG-to-PDF conversion, install `librsvg` (`brew install librsvg` on macOS). If `mmdc` is not installed, mermaid blocks pass through as code listings.
 
 ### Citations and bibliography
 

--- a/examples/demo-default.md
+++ b/examples/demo-default.md
@@ -29,7 +29,7 @@ inkwell:
 
 # Introduction {#sec:intro}
 
-This document demonstrates the default Inkwell template. It compiles markdown to publication-quality PDF through Pandoc [@macfarlane2023] and XeLaTeX, with code blocks that execute in place. The result is a literate programming workflow where analysis and writing coexist in a single file [@knuth1984].
+This document demonstrates the default Inkwell template. It compiles markdown to publication-quality PDF through Pandoc [@macfarlane2023] and XeLaTeX, with code blocks that execute in place. The result is a literate programming workflow where analysis and writing coexist in a single file [@knuth1984]. Mermaid diagrams (@sec:diagrams) also compile inline as cross-referenceable SVG figures.
 
 ## Runnable Code: Fourier Partial Sums {#sec:fourier}
 
@@ -129,6 +129,19 @@ $$e^{i\pi} + 1 = 0$$ {#eq:euler}
 **Cauchy-Schwarz Inequality.** For all vectors $u, v$ in an inner product space,
 $$|\langle u, v \rangle|^2 \leq \langle u, u \rangle \cdot \langle v, v \rangle$$ {#eq:cauchy-schwarz}
 :::
+
+## Diagrams {#sec:diagrams}
+
+Mermaid diagrams render to SVG and are cross-referenceable like any figure. @Fig:pipeline shows the Inkwell compilation pipeline.
+
+```{mermaid caption="The Inkwell compilation pipeline, from source markdown to final PDF." label="pipeline"}
+graph LR
+    A[Markdown + YAML] --> B[Run Code Blocks]
+    B --> C[Inject Results]
+    C --> D[Bind Variables]
+    D --> E[Pandoc + XeLaTeX]
+    E --> F[PDF]
+```
 
 ## Environment
 

--- a/guide.md
+++ b/guide.md
@@ -178,6 +178,59 @@ Set a document-wide default with `code-display:` in the `inkwell:` namespace.
 
 ---
 
+## Mermaid Diagrams
+
+Mermaid diagrams render to SVG at compile time via `mmdc` (mermaid-cli). The preview panel renders them client-side. Both `{mermaid}` (with attributes) and plain `mermaid` fences are supported.
+
+### With caption and cross-reference
+
+````markdown
+```{mermaid caption="System architecture" label="arch"}
+graph LR
+    A[Client] --> B[API]
+    B --> C[Database]
+```
+````
+
+This produces a numbered figure referenceable as `@Fig:arch`.
+
+### Plain (no caption)
+
+````markdown
+```mermaid
+sequenceDiagram
+    Alice->>Bob: Hello
+    Bob-->>Alice: Hi back
+```
+````
+
+### Supported diagram types
+
+Any diagram type that `mmdc` supports works: `graph`, `sequenceDiagram`, `classDiagram`, `stateDiagram`, `erDiagram`, `gantt`, `pie`, `flowchart`, `gitgraph`, `mindmap`, `timeline`, and others.
+
+### Caching
+
+Rendered SVGs are cached in `.inkwell/mermaid/` by content hash. A diagram only re-renders when its source changes.
+
+### Prerequisites
+
+Install mermaid-cli globally:
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+For SVG support in PDF output, install `librsvg` so Pandoc can convert SVGs to PDF:
+
+```bash
+brew install librsvg          # macOS
+sudo apt install librsvg2-bin  # Debian/Ubuntu
+```
+
+If `mmdc` is not installed, mermaid blocks pass through as code listings.
+
+---
+
 ## Inline Data Binding
 
 Code blocks can export named values that you reference later in prose, captions, or table cells. There are two mechanisms.

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -447,26 +447,143 @@ function applyInlineResults(
   return result;
 }
 
+// ── Layer 3: Mermaid diagrams ─────────────────────────────────────────
+
+const MERMAID_BLOCK_RE = /^```(?:\{mermaid([^}]*)\}|mermaid)\s*\n([\s\S]*?)^```/gm;
+
+let _mmdcAvailable: boolean | undefined;
+
+function mmdcAvailable(): boolean {
+  if (_mmdcAvailable !== undefined) return _mmdcAvailable;
+  try {
+    execFileSync("mmdc", ["--version"], {
+      encoding: "utf-8", timeout: 5000, stdio: "pipe",
+    });
+    _mmdcAvailable = true;
+  } catch {
+    _mmdcAvailable = false;
+  }
+  return _mmdcAvailable;
+}
+
+function parseMermaidAttrs(raw: string | undefined): Record<string, string> {
+  if (!raw?.trim()) return {};
+  const attrs: Record<string, string> = {};
+  const re = /(\w+)="([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(raw)) !== null) {
+    attrs[m[1]] = m[2];
+  }
+  return attrs;
+}
+
+export function renderMermaidBlocks(markdown: string, workDir: string): string {
+  if (!mmdcAvailable()) return markdown;
+
+  const matches: { raw: string; attrsStr?: string; source: string }[] = [];
+  MERMAID_BLOCK_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = MERMAID_BLOCK_RE.exec(markdown)) !== null) {
+    matches.push({ raw: m[0], attrsStr: m[1], source: m[2].trim() });
+  }
+  if (!matches.length) return markdown;
+
+  const mermaidDir = path.join(workDir, ".inkwell", "mermaid");
+  fs.mkdirSync(mermaidDir, { recursive: true });
+
+  let output = markdown;
+  let offset = 0;
+
+  for (const match of matches) {
+    const attrs = parseMermaidAttrs(match.attrsStr);
+    const hash = crypto
+      .createHash("sha256")
+      .update(match.source)
+      .digest("hex")
+      .substring(0, 16);
+
+    const svgPath = path.join(mermaidDir, `${hash}.svg`);
+    const metaPath = path.join(mermaidDir, `${hash}.json`);
+
+    let cached = false;
+    try {
+      const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+      if (meta.hash === hash && fs.existsSync(svgPath)) cached = true;
+    } catch {}
+
+    if (!cached) {
+      const inputPath = path.join(mermaidDir, `${hash}.mmd`);
+      fs.writeFileSync(inputPath, match.source, "utf-8");
+      try {
+        execFileSync("mmdc", ["-i", inputPath, "-o", svgPath], {
+          cwd: workDir,
+          timeout: 30_000,
+          stdio: "pipe",
+        });
+        // mmdc v9 and earlier may append -1 to the filename
+        if (!fs.existsSync(svgPath)) {
+          const alt = svgPath.replace(".svg", "-1.svg");
+          if (fs.existsSync(alt)) fs.renameSync(alt, svgPath);
+        }
+        if (fs.existsSync(svgPath)) {
+          fs.writeFileSync(metaPath, JSON.stringify({ hash }), "utf-8");
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    if (!fs.existsSync(svgPath)) continue;
+
+    const alt = attrs.caption || "Mermaid diagram";
+    const labelAttr = attrs.label ? `{#fig:${attrs.label}}` : "";
+    const replacement = `![${alt}](${svgPath})${labelAttr}`;
+
+    const start = output.indexOf(match.raw, offset);
+    if (start === -1) continue;
+
+    output =
+      output.substring(0, start) +
+      replacement +
+      output.substring(start + match.raw.length);
+    offset = start + replacement.length;
+  }
+
+  return output;
+}
+
+function normalizeMermaidForPreview(markdown: string): string {
+  return markdown.replace(/^```\{mermaid[^}]*\}\s*$/gm, "```mermaid");
+}
+
+// ── Compilation and preview entry points ──────────────────────────────
+
 export function prepareForCompilation(
   markdown: string,
   sourceFile: string,
 ): { injected: string; tempFile: string } {
   const workDir = path.dirname(sourceFile);
-  const blocks = parseCodeBlocks(markdown);
-  const hasBlocks = blocks.length > 0;
-  const hasVarRefs = /\{\{\w+\}\}/.test(markdown);
-  const hasInlineExprs = /`\{python\}\s+[^`]+`/.test(markdown);
 
-  if (!hasBlocks && !hasVarRefs && !hasInlineExprs) {
+  const hasMermaid = /^```(?:\{mermaid|mermaid)/m.test(markdown);
+  const processed = hasMermaid
+    ? renderMermaidBlocks(markdown, workDir)
+    : markdown;
+
+  const blocks = parseCodeBlocks(processed);
+  const hasBlocks = blocks.length > 0;
+  const hasVarRefs = /\{\{\w+\}\}/.test(processed);
+  const hasInlineExprs = /`\{python\}\s+[^`]+`/.test(processed);
+
+  if (!hasBlocks && !hasVarRefs && !hasInlineExprs && !hasMermaid) {
     return { injected: markdown, tempFile: sourceFile };
   }
 
-  const runConfig = parseRunConfig(markdown);
+  const runConfig = parseRunConfig(processed);
   const defaultDisplay = runConfig.defaultDisplay || "output";
-  const results = gatherCachedResults(markdown, sourceFile);
+  const results = gatherCachedResults(processed, sourceFile);
   const vars = collectVariables(results);
 
-  let injected = injectResults(markdown, results, defaultDisplay, workDir);
+  let injected = injectResults(processed, results, defaultDisplay, workDir);
   injected = substituteVariables(injected, vars);
 
   const cacheDir = path.join(workDir, ".inkwell", "outputs");
@@ -484,20 +601,25 @@ export function prepareForPreview(
   markdown: string,
   sourceFile: string,
 ): string {
-  const blocks = parseCodeBlocks(markdown);
-  const hasBlocks = blocks.length > 0;
-  const hasVarRefs = /\{\{\w+\}\}/.test(markdown);
-  const hasInlineExprs = /`\{python\}\s+[^`]+`/.test(markdown);
+  const hasMermaid = /^```\{mermaid/m.test(markdown);
+  const processed = hasMermaid
+    ? normalizeMermaidForPreview(markdown)
+    : markdown;
 
-  if (!hasBlocks && !hasVarRefs && !hasInlineExprs) return markdown;
+  const blocks = parseCodeBlocks(processed);
+  const hasBlocks = blocks.length > 0;
+  const hasVarRefs = /\{\{\w+\}\}/.test(processed);
+  const hasInlineExprs = /`\{python\}\s+[^`]+`/.test(processed);
+
+  if (!hasBlocks && !hasVarRefs && !hasInlineExprs) return processed;
 
   const workDir = path.dirname(sourceFile);
-  const runConfig = parseRunConfig(markdown);
+  const runConfig = parseRunConfig(processed);
   const defaultDisplay = runConfig.defaultDisplay || "both";
-  const results = gatherCachedResults(markdown, sourceFile);
+  const results = gatherCachedResults(processed, sourceFile);
   const vars = collectVariables(results);
 
-  let injected = injectResults(markdown, results, defaultDisplay, workDir);
+  let injected = injectResults(processed, results, defaultDisplay, workDir);
   injected = substituteVariables(injected, vars);
 
   const cacheDir = path.join(workDir, ".inkwell", "outputs");

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -140,6 +140,7 @@ export function parseCodeBlocks(markdown: string): CodeBlock[] {
   BLOCK_PATTERN.lastIndex = 0;
   while ((match = BLOCK_PATTERN.exec(markdown)) !== null) {
     const lang = match[1];
+    if (lang === "mermaid") continue;
     const attrsStr = match[2].trim();
     const source = match[3];
     const raw = match[0];


### PR DESCRIPTION
## Summary

- Mermaid fenced blocks (`{mermaid caption="..." label="..."}` and plain ` ```mermaid `) now render to SVG via `mmdc` at compile time, cached by content hash in `.inkwell/mermaid/`
- SVG images are replaced with Pandoc image references supporting `caption` and `label` attributes for full `pandoc-crossref` numbering and cross-references (`@Fig:label`)
- Preview panel still uses client-side mermaid.js; compilation path uses `mmdc` + `rsvg-convert` for SVG-to-PDF in LaTeX
- Mermaid blocks are filtered from the code runner so they do not interfere with block indexing or execution
- Updated guide.md, README.md, and demo-default.md with documentation and a working example

## Test plan

- [ ] Add a `{mermaid caption="..." label="..."}` block to a document, run Compile, verify SVG renders as a numbered figure in the PDF
- [ ] Add a plain ` ```mermaid ` block, verify it renders in the preview panel via client-side mermaid.js
- [ ] Verify cross-references (`@Fig:label`) resolve correctly in the compiled PDF
- [ ] Verify caching: edit the diagram source and recompile; confirm a new SVG is generated. Leave source unchanged and recompile; confirm the cached SVG is reused
- [ ] Verify graceful degradation: uninstall `mmdc`, compile a document with mermaid blocks, confirm they appear as code listings instead of crashing
- [ ] Verify existing code blocks (Python, R, Shell) still run and cache correctly with mermaid blocks present in the same document

Closes #17