### PR TITLE
fix: tables fail with Pandoc 3.x; extension commands missing in fresh installs

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,6 +11,13 @@ tsconfig.json
 .git/**
 .gitignore
 node_modules/**
+!node_modules/markdown-it/**
+!node_modules/argparse/**
+!node_modules/entities/**
+!node_modules/linkify-it/**
+!node_modules/mdurl/**
+!node_modules/punycode.js/**
+!node_modules/uc.micro/**
 
 # Documentation and examples
 examples/**

--- a/templates/inkwell.latex
+++ b/templates/inkwell.latex
@@ -23,6 +23,7 @@ $if(linestretch)$\setstretch{$linestretch$}$else$\setstretch{1.4}$endif$
 \declaretheorem[style=inkwell-def,numbered=no]{example}
 \declaretheorem[style=inkwell-def,numbered=no]{remark}
 \usepackage{enumitem}
+\usepackage{array}
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{graphicx}

--- a/templates/ludus/ludus.latex
+++ b/templates/ludus/ludus.latex
@@ -25,6 +25,7 @@ $endif$
 
 % Packages not already provided by ludusofficial.cls
 \usepackage{amsmath,amssymb}
+\usepackage{array}
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{enumitem}

--- a/templates/rho/rho.latex
+++ b/templates/rho/rho.latex
@@ -55,6 +55,7 @@ $endif$
 $if(keywords)$\keywords{$keywords$}$endif$
 
 % Pandoc longtable in twocolumn: redirect to table float + tabular.
+\usepackage{array}
 \usepackage{longtable}
 \makeatletter
 \newcommand{\rho@colspec}{}


### PR DESCRIPTION
## Summary

- Add `\usepackage{array}` to `inkwell.latex`, `ludus/ludus.latex`, and `rho/rho.latex` so Pandoc 3.x table column specs (`\arraybackslash`) compile correctly.
- Add exclusion overrides in `.vscodeignore` to preserve `markdown-it` and its transitive dependencies in the packaged `.vsix`, fixing silent extension activation failure in fresh installs.

Closes #25

## Test plan

- [ ] Compile a document with a Pandoc-generated table using each of the three fixed templates (inkwell, ludus, rho) and confirm no `\arraybackslash` error
- [ ] Run `npx @vscode/vsce package` and verify `markdown-it` appears in the resulting `.vsix`
- [ ] Install the `.vsix` in a fresh Cursor/VS Code window and confirm all Inkwell commands register