### PR TITLE
fix: hide code blocks in preview by default, resolve capitalized cross-refs

### DIFF
--- a/src/inject.ts
+++ b/src/inject.ts
@@ -52,7 +52,9 @@ const PANDOC_LANG_MAP: Record<string, string> = {
 const INKWELL_VAR_RE = /^::inkwell\s+(\w+)=(.+)$/;
 
 function resolveDisplay(block: CodeBlock, defaultDisplay: DisplayMode): DisplayMode {
-  return block.display || defaultDisplay;
+  if (block.display) return block.display;
+  if (block.file) return "output";
+  return defaultDisplay;
 }
 
 // ── Layer 1: Variable store ───────────────────────────────────────────
@@ -655,7 +657,7 @@ export function prepareForPreview(
 
   const workDir = path.dirname(sourceFile);
   const runConfig = parseRunConfig(processed);
-  const defaultDisplay = runConfig.defaultDisplay || "both";
+  const defaultDisplay = runConfig.defaultDisplay || "output";
   const results = gatherCachedResults(processed, sourceFile);
   const vars = collectVariables(results);
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1185,12 +1185,12 @@ function resolveReferences(
     },
   );
 
-  // Replace @type:label references with clickable links
+  // Replace @type:label references with clickable links (case-insensitive)
   result = result.replace(
-    /@(fig|sec|tbl|eq):([\w:.-]+)/g,
+    /@(fig|sec|tbl|eq):([\w:.-]+)/gi,
     (_, type: string, id: string) => {
-      const label = `${type}:${id}`;
-      const display = labels.get(label) || `${type}:${id}`;
+      const label = `${type.toLowerCase()}:${id}`;
+      const display = labels.get(label) || `${type.toLowerCase()}:${id}`;
       return `<a href="#${label}" class="cross-ref">${display}</a>`;
     },
   );


### PR DESCRIPTION
## Summary

- **Preview display default**: changed from `"both"` to `"output"` so code blocks show only their results in the HTML preview, not the script source. File-based blocks (`file="..."`) always default to `"output"` regardless of global setting. Users can still override per-block with `display="both"` or `display="code"`.
- **Cross-reference case**: `@Fig:`, `@Sec:`, `@Tbl:`, `@Eq:` (capitalized Pandoc-crossref forms) now resolve correctly alongside their lowercase equivalents.

## Test plan

- [ ] Open `examples/demo-default.md` preview; verify Python code blocks show only output (figures, tables), not script source
- [ ] Verify `@Fig:scatter` and other capitalized cross-references render as clickable links
- [ ] Verify a block with explicit `display="both"` still shows code + output