### PR TITLE
fix: render table captions as HTML, clean up unresolved variable display

### DIFF
--- a/media/preview.css
+++ b/media/preview.css
@@ -121,6 +121,35 @@ tbody tr:last-child { border-bottom: 2px solid var(--rule-color); }
 /* Subtle alternating row shading */
 tbody tr:nth-child(even) { background: var(--code-bg); }
 
+/* Table captions (below tables, matching LaTeX \caption style) */
+.table-caption {
+    font-size: 0.9em;
+    color: var(--blockquote);
+    margin-top: 0.4em;
+    margin-bottom: 1.5em;
+    text-align: left;
+}
+.table-caption strong { color: var(--text); }
+
+/* Unresolved variable placeholders */
+.var-placeholder {
+    font-family: var(--mono-font);
+    font-size: 0.85em;
+    color: var(--blockquote);
+    background: var(--code-bg);
+    padding: 1px 4px;
+    border-radius: 2px;
+    border: 1px dashed var(--border);
+}
+
+/* Inline expression evaluation errors */
+.eval-error {
+    font-family: var(--mono-font);
+    font-size: 0.85em;
+    color: #cc4444;
+    cursor: help;
+}
+
 img {
     max-width: 100%;
     margin: 1em 0;

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -205,6 +205,16 @@ export class InkwellPreviewProvider {
       body = resolveCitations(body);
       // Strip any remaining Pandoc header attributes not caught above
       body = body.replace(/\s*\{[#.][\w:. -]+\}\s*$/gm, "");
+      // Clean up unresolved inline expression errors for preview
+      body = body.replace(
+        /\?\?\(([^)]+)\)/g,
+        '<span class="eval-error" title="$1">??</span>',
+      );
+      // Style unresolved {{variable}} placeholders (outside math)
+      body = body.replace(
+        /(?<!\$)\{\{(\w+)\}\}(?!\$)/g,
+        '<span class="var-placeholder">$1</span>',
+      );
 
       let rendered = md.render(body);
       rendered = this.convertLocalImages(rendered, document);
@@ -1165,13 +1175,13 @@ function resolveReferences(
     return match;
   });
 
-  // Table caption labels: : caption {#tbl:label}
+  // Table caption labels: : caption {#tbl:label} -> HTML figcaption
   result = result.replace(
     /^:\s+(.*?)\s*\{#(tbl:[\w:.-]+)\}\s*$/gm,
     (_, caption: string, label: string) => {
       tblNum++;
       labels.set(label, `${prefixes.tbl}\u00a0${tblNum}`);
-      return `: ${prefixes.tbl} ${tblNum}: ${caption}`;
+      return `<figcaption class="table-caption"><a id="${label}"></a><strong>${prefixes.tbl}\u00a0${tblNum}:</strong> ${caption}</figcaption>`;
     },
   );
 


### PR DESCRIPTION
## Summary

- **Table captions**: Pandoc `: caption {#tbl:label}` syntax now renders as styled `<figcaption>` elements with bold label prefix (e.g., "**Table 1:** caption text") instead of raw `: table 1:` text that markdown-it passes through as a paragraph.
- **Unresolved `{{variable}}`**: styled as monospace badges with dashed borders instead of raw double-brace text leaking into the document.
- **Inline expression errors**: `??(name 'slope' is not defined)` now renders as a red `??` with the full error in a hover tooltip, rather than dumping the Python error inline.

## Test plan

- [ ] Open `examples/demo-ludus.md` preview; verify table caption below the convergence table renders as "**Table 1:** Convergence of Fourier partial sums..." (styled, not raw `: table 1:`)
- [ ] Verify unresolved `{{sample_n}}` shows as a styled placeholder (not raw braces)
- [ ] Verify `??(...)` errors show as a small red `??` with tooltip on hover
- [ ] Run code blocks, reload preview, verify placeholders resolve to actual values