### PR TITLE
fix: make preview content fill the panel width

### DIFF
--- a/media/preview.css
+++ b/media/preview.css
@@ -35,12 +35,16 @@ body {
     line-height: var(--line-height);
     color: var(--text);
     background: var(--bg);
-    max-width: var(--content-width);
-    margin: 0 auto;
-    padding: 32px 24px;
+    margin: 0;
+    padding: 0;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     font-feature-settings: "liga", "kern";
+}
+
+#preview-content {
+    max-width: var(--content-width);
+    margin: 0 auto;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -405,7 +405,7 @@ export class InkwellPreviewProvider {
       --mono-font: 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
       --base-size: 16px;
       --line-height: 1.5;
-      --content-width: 680px;
+      --content-width: 100%;
       --paragraph-spacing: 0.8em;
       --hr-display: block;
     }


### PR DESCRIPTION
## Summary

- Moved `max-width` from `body` to `#preview-content` (the article element). The body max-width was constraining the entire webview layout, including toolbar and PDF pane.
- Changed `--content-width` from `680px` to `100%` so the preview content fills the available panel width instead of leaving empty margins.
- Preview pane padding (`32px 24px`) continues to provide comfortable reading margins.

## Test plan

- [ ] Open preview panel at various widths; verify content stretches to fill the panel
- [ ] Verify toolbar spans the full panel width
- [ ] Verify PDF pane is not affected (should still work normally)