### PR TITLE
docs: add Tufte formatting guide and fix demo to use raw LaTeX

### DIFF
--- a/.cursor/agents/inkwell-guide.md
+++ b/.cursor/agents/inkwell-guide.md
@@ -24,11 +24,69 @@ The complete syntax reference is in `guide.md` at the repository root. Consult i
 4. Convert the body to Pandoc-flavored markdown following the conversion table in GUIDE.md.
 5. Present the complete converted document. Do not omit sections.
 
+## Tufte template
+
+The `tufte-handout` class has features that require raw LaTeX. Pandoc's fenced div conversion (`::: {.class}`) is unreliable for these; prefer raw LaTeX.
+
+### Margin notes
+
+Use `\sidenote{text}` (numbered, with superscript marker) or `\marginnote{text}` (unnumbered). Keep to 1-2 sentences. Multi-paragraph content breaks margin placement.
+
+```markdown
+The data-ink ratio\sidenote{Tufte introduced this concept in 1983.} measures
+the proportion of ink devoted to non-redundant data display.
+```
+
+Do NOT use `::: {.aside}` for anything beyond a single short paragraph. It depends on the `environ` package capturing `\BODY`, which fails with complex content.
+
+### Full-width sections
+
+Wrap content in raw LaTeX:
+
+```markdown
+\begin{fullwidth}
+| Col A | Col B | Col C | Col D | Col E |
+|-------|-------|-------|-------|-------|
+| 1     | 2     | 3     | 4     | 5     |
+
+: Wide table caption. {#tbl:wide}
+\end{fullwidth}
+```
+
+Do NOT use `::: {.fullwidth}`. It can fail silently depending on the Pandoc version.
+
+### Margin figures
+
+Always raw LaTeX. No Pandoc markdown equivalent exists.
+
+```markdown
+\begin{marginfigure}
+\centering
+\includegraphics[width=\linewidth]{figures/plot.pdf}
+\caption{Caption in the margin.}
+\end{marginfigure}
+```
+
+### New thought
+
+`\newthought{First few words}` renders the opening phrase in small caps. Use at the start of major sections or topic shifts.
+
+### Tufte frontmatter
+
+```yaml
+template: tufte
+classoption:
+  - justified      # justified text (default is ragged-right)
+  - a4paper        # or letterpaper (default)
+  # - sfsidenotes  # sans-serif sidenotes
+```
+
 ## Rules
 
 - The output must be a single `.md` file with valid YAML frontmatter.
 - Preserve the source's intellectual content exactly. Only change formatting.
 - Keep raw LaTeX for equation environments, TikZ, and custom environments.
+- For Tufte documents, use raw LaTeX for margin notes, full-width sections, and margin figures. Do not use fenced divs for these features.
 - Convert all `\cite` variants to Pandoc syntax: `[@key]`, `@key`, `[@a; @b]`.
 - Set `bibliography:` and `link-citations: true` in frontmatter.
 - If parts of the LaTeX cannot be cleanly converted, keep them as raw LaTeX blocks.

--- a/.cursor/rules/tufte-format.mdc
+++ b/.cursor/rules/tufte-format.mdc
@@ -1,0 +1,62 @@
+---
+description: Tufte template formatting conventions for margin notes, sidenotes, full-width sections, and margin figures
+globs: "examples/demo-tufte*,templates/tufte/**"
+alwaysApply: false
+---
+
+# Tufte Template Formatting
+
+The `tufte-handout` class provides margin notes, sidenotes, margin figures, and full-width sections. Some of these require raw LaTeX because Pandoc's fenced div conversion is unreliable for complex content.
+
+## Margin text
+
+Use `\sidenote{text}` (numbered) or `\marginnote{text}` (unnumbered). Keep content to 1-2 sentences.
+
+```markdown
+The data-ink ratio\sidenote{Tufte introduced this concept in 1983.} measures
+the proportion of ink devoted to non-redundant data display.
+```
+
+The `::: {.aside}` fenced div works for short text but breaks with paragraphs or math. Prefer raw LaTeX.
+
+## Full-width sections
+
+Wrap content in raw LaTeX, not fenced divs:
+
+```markdown
+\begin{fullwidth}
+| Col A | Col B | Col C | Col D | Col E |
+|-------|-------|-------|-------|-------|
+| 1     | 2     | 3     | 4     | 5     |
+
+: Wide table caption. {#tbl:wide}
+\end{fullwidth}
+```
+
+`::: {.fullwidth}` can fail silently depending on Pandoc version. Raw LaTeX is reliable.
+
+## Margin figures
+
+Always raw LaTeX:
+
+```markdown
+\begin{marginfigure}
+\centering
+\includegraphics[width=\linewidth]{figures/plot.pdf}
+\caption{Caption in the margin.}
+\end{marginfigure}
+```
+
+## New thought (paragraph opener)
+
+```markdown
+\newthought{The fundamental principle} of analytical design is to show the data.
+```
+
+Renders the opening phrase in small caps. Use at the start of major sections.
+
+## What to avoid
+
+- Multi-paragraph content inside `\sidenote{}` or `\marginnote{}`
+- Fenced divs (`::: {.fullwidth}`, `::: {.aside}`) for anything beyond simple text
+- `\begin{figure*}` (use `\begin{fullwidth}` with a standard figure inside)

--- a/examples/demo-tufte.md
+++ b/examples/demo-tufte.md
@@ -58,10 +58,7 @@ inkwell:
 data. Every bit of ink on a graphic requires a reason. If the ink
 does not tell the viewer something new, it should be erased.
 
-::: {.aside}
-Edward Tufte introduced the *data-ink ratio* in *The Visual Display
-of Quantitative Information* (1983).
-:::
+\marginnote{Edward Tufte introduced the \emph{data-ink ratio} in \emph{The Visual Display of Quantitative Information} (1983).}
 
 Consider the ratio of data-ink to total ink in a graphic. A chart burdened
 with gridlines, redundant labels, and decorative hatching distracts from
@@ -74,11 +71,7 @@ reason, and the result is a clearer picture.
 datasets that share nearly identical summary statistics yet look
 completely different when plotted.
 
-::: {.aside}
-Anscombe's quartet demonstrates why visualization matters:
-$\bar{x} = 9$, $\bar{y} \approx 7.5$, and $r^2 = 0.67$ for
-all four sets, yet the patterns differ radically.
-:::
+\marginnote{Anscombe's quartet demonstrates why visualization matters: $\bar{x} = 9$, $\bar{y} \approx 7.5$, and $r^2 = 0.67$ for all four sets, yet the patterns differ radically.}
 
 The quartet drives home a simple lesson: always plot your data.
 Summary statistics alone can mislead.
@@ -142,9 +135,9 @@ graphics alongside the narrative.
 
 ## Full-Width Sections {#sec:fullwidth}
 
-::: {.fullwidth}
+\begin{fullwidth}
 
-When a table or figure demands the full page width, the `fullwidth`
+When a table or figure demands the full page width, the \texttt{fullwidth}
 environment extends into the margin area. This is useful for wide tables
 or panoramic figures that lose clarity when constrained.
 
@@ -157,7 +150,7 @@ or panoramic figures that lose clarity when constrained.
 
 : Summary statistics of the Anscombe quartet. {#tbl:anscombe-stats}
 
-:::
+\end{fullwidth}
 
 # Mathematical Notation {#sec:math}
 


### PR DESCRIPTION
## Summary

- **New rule**: `.cursor/rules/tufte-format.mdc` with Tufte-specific formatting guidance (margin notes, full-width, margin figures, `\newthought`). Applies when working with Tufte template files.
- **Updated agent**: `inkwell-guide.md` now includes a Tufte section documenting when to use raw LaTeX vs fenced divs, with concrete examples.
- **Fixed demo**: `examples/demo-tufte.md` converted from fenced divs (`::: {.aside}`, `::: {.fullwidth}`) to raw LaTeX (`\marginnote`, `\begin{fullwidth}`), which compiles reliably across Pandoc versions.

Key guidance: Pandoc fenced divs (`::: {.aside}`, `::: {.fullwidth}`) are fragile for Tufte features. Use raw LaTeX (`\marginnote{}`, `\sidenote{}`, `\begin{fullwidth}`, `\begin{marginfigure}`) instead.

## Test plan

- [ ] Compile `examples/demo-tufte.md` to PDF; verify margin notes, full-width table, and margin figure render correctly
- [ ] Verify `\newthought` renders opening phrase in small caps
- [ ] Open `.cursor/rules/tufte-format.mdc` and verify it loads in Cursor's rule system