### PR TITLE
fix: clarify missing python env recovery path

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -256,10 +256,18 @@ function resolveInterpreter(
     return { cmd: resolved, args: defaultArgs, envVars: {}, label: resolved };
   }
 
+  let warning = `Environment "${envSpec}" not found at ${resolved}. Using system ${defaultCmd}. Run "Inkwell: Setup Python Env" to create it.`;
+  if (langKey.startsWith("python")) {
+    const reqFile = path.join(workDir, "requirements.txt");
+    if (fs.existsSync(reqFile)) {
+      warning += ` Found requirements.txt at ${reqFile}; run setup from this document folder and choose "${envSpec}" to auto-install dependencies.`;
+    }
+  }
+
   return {
     cmd: defaultCmd, args: defaultArgs, envVars: {},
     label: defaultCmd,
-    warning: `Environment "${envSpec}" not found at ${resolved}. Using system ${defaultCmd}. Run "Inkwell: Setup Python Env" to create it.`,
+    warning,
   };
 }
 


### PR DESCRIPTION
## Summary
- improve Python missing-env fallback warning in `runner.ts`
- when `requirements.txt` exists in the document folder, include explicit recovery guidance to run `Inkwell: Setup Python Env` with the configured env path
- reduce confusion for demo docs that use `inkwell.python-env: ./venv`

## Test plan
- [x] `npm run compile`
- [x] pre-commit verify suite passed (`typecheck`, `lint`, template regressions)
- [x] manual validation of warning path for missing `./venv`

## Related
- Issue #40