### PR TITLE
feat: bootstrap workspace .inkwell for non-project repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
         "category": "Inkwell"
       },
       {
+        "command": "inkwell.bootstrapWorkspaceInkwell",
+        "title": "Inkwell: Bootstrap Workspace (.inkwell Folder)",
+        "category": "Inkwell"
+      },
+      {
         "command": "inkwell.updateProject",
         "title": "Inkwell: Update Project",
         "category": "Inkwell"
@@ -168,11 +173,22 @@
       }
     },
     "menus": {
+      "commandPalette": [
+        {
+          "command": "inkwell.bootstrapWorkspaceInkwell",
+          "when": "!inkwell.hasProject"
+        }
+      ],
       "editor/title": [
         {
           "command": "inkwell.preview",
           "when": "editorLangId == markdown || editorLangId == latex",
           "group": "navigation"
+        },
+        {
+          "command": "inkwell.bootstrapWorkspaceInkwell",
+          "when": "(editorLangId == markdown || editorLangId == latex) && !inkwell.hasProject",
+          "group": "navigation@1"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { findInkwellRoot, saveManifestField } from "./config";
 import { checkToolchain, showToolchainStatus, setExtensionPath } from "./toolchain";
 import { runAllBlocks, parseCodeBlocks, RunCancellation } from "./runner";
 import { clearCache } from "./cache";
-import { initProject, updateProject } from "./scaffold";
+import { bootstrapWorkspaceInkwell, initProject, updateProject } from "./scaffold";
 import * as path from "path";
 import * as fs from "fs";
 
@@ -124,6 +124,10 @@ export function activate(context: vscode.ExtensionContext) {
       initProject();
     }),
 
+    vscode.commands.registerCommand("inkwell.bootstrapWorkspaceInkwell", () => {
+      bootstrapWorkspaceInkwell();
+    }),
+
     vscode.commands.registerCommand("inkwell.updateProject", () => {
       updateProject();
     }),
@@ -145,6 +149,19 @@ export function activate(context: vscode.ExtensionContext) {
     }),
 
     diagnostics
+  );
+
+  refreshProjectContextKey();
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      refreshProjectContextKey();
+    }),
+    vscode.workspace.onDidOpenTextDocument(() => {
+      refreshProjectContextKey();
+    }),
+    vscode.workspace.onDidCloseTextDocument(() => {
+      refreshProjectContextKey();
+    }),
   );
 
   setupAutoCompileTimer();
@@ -337,4 +354,18 @@ async function activationCheck() {
   if (choice === "Setup now") {
     showToolchainStatus();
   }
+}
+
+function refreshProjectContextKey(): void {
+  const editor = vscode.window.activeTextEditor;
+  let hasInkwellProject = false;
+
+  if (editor) {
+    hasInkwellProject = Boolean(findInkwellRoot(editor.document.uri));
+  } else if (vscode.workspace.workspaceFolders?.length) {
+    const base = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    hasInkwellProject = fs.existsSync(path.join(base, ".inkwell"));
+  }
+
+  void vscode.commands.executeCommand("setContext", "inkwell.hasProject", hasInkwellProject);
 }

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -157,22 +157,70 @@ const MANIFEST_TEMPLATE = (template?: string) =>
     2
   ) + "\n";
 
-export async function initProject(): Promise<void> {
+async function pickWorkspaceRoot(
+  openLabel: string
+): Promise<string | undefined> {
   const workspaceFolders = vscode.workspace.workspaceFolders;
-  let baseDir: string;
-
-  if (workspaceFolders?.length) {
-    baseDir = workspaceFolders[0].uri.fsPath;
-  } else {
-    const picked = await vscode.window.showOpenDialog({
-      canSelectFolders: true,
-      canSelectFiles: false,
-      canSelectMany: false,
-      openLabel: "Select project folder",
-    });
-    if (!picked?.[0]) return;
-    baseDir = picked[0].fsPath;
+  if (workspaceFolders?.length === 1) {
+    return workspaceFolders[0].uri.fsPath;
   }
+  if (workspaceFolders && workspaceFolders.length > 1) {
+    const items = workspaceFolders.map((wf) => ({
+      label: wf.name,
+      detail: wf.uri.fsPath,
+      path: wf.uri.fsPath,
+    }));
+    const picked = await vscode.window.showQuickPick(items, {
+      placeHolder: "Choose a workspace folder for Inkwell setup",
+    });
+    return picked?.path;
+  }
+
+  const picked = await vscode.window.showOpenDialog({
+    canSelectFolders: true,
+    canSelectFiles: false,
+    canSelectMany: false,
+    openLabel,
+  });
+  return picked?.[0]?.fsPath;
+}
+
+function copyMissingDirectory(src: string, dest: string): void {
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.cpSync(src, dest, {
+    recursive: true,
+    force: false,
+    errorOnExist: false,
+  });
+}
+
+function seedProjectTemplates(projectRoot: string): string[] {
+  const bundledTemplatesDir = path.join(__dirname, "..", "templates");
+  const projectTemplatesDir = path.join(projectRoot, ".inkwell", "templates");
+  const copied: string[] = [];
+
+  if (!fs.existsSync(bundledTemplatesDir)) return copied;
+  fs.mkdirSync(projectTemplatesDir, { recursive: true });
+
+  for (const entry of fs.readdirSync(bundledTemplatesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue;
+
+    const src = path.join(bundledTemplatesDir, entry.name);
+    const dest = path.join(projectTemplatesDir, entry.name);
+    if (!fs.existsSync(dest)) {
+      copyMissingDirectory(src, dest);
+      copied.push(entry.name);
+    }
+  }
+
+  return copied;
+}
+
+export async function initProject(): Promise<void> {
+  const baseDir = await pickWorkspaceRoot("Select project folder");
+  if (!baseDir) return;
 
   const name = await vscode.window.showInputBox({
     prompt: "Project name (used for the main document filename)",
@@ -215,6 +263,67 @@ export async function initProject(): Promise<void> {
   await vscode.window.showTextDocument(doc);
 
   vscode.window.showInformationMessage(`Inkwell project "${options.name}" initialized.`);
+}
+
+export async function bootstrapWorkspaceInkwell(): Promise<void> {
+  const baseDir = await pickWorkspaceRoot("Select workspace root");
+  if (!baseDir) return;
+
+  const report: string[] = [];
+  const inkwellDir = path.join(baseDir, ".inkwell");
+  const outputsDir = path.join(inkwellDir, "outputs");
+  const templatesDir = path.join(inkwellDir, "templates");
+  const manifestPath = path.join(inkwellDir, "manifest.json");
+
+  if (!fs.existsSync(inkwellDir)) {
+    fs.mkdirSync(inkwellDir, { recursive: true });
+    report.push("created .inkwell/");
+  }
+  if (!fs.existsSync(outputsDir)) {
+    fs.mkdirSync(outputsDir, { recursive: true });
+    report.push("created .inkwell/outputs/");
+  }
+  if (!fs.existsSync(templatesDir)) {
+    fs.mkdirSync(templatesDir, { recursive: true });
+    report.push("created .inkwell/templates/");
+  }
+  if (!fs.existsSync(manifestPath)) {
+    fs.writeFileSync(manifestPath, MANIFEST_TEMPLATE("inkwell"), "utf-8");
+    report.push("created .inkwell/manifest.json");
+  }
+
+  const copyTemplates = await vscode.window.showQuickPick(
+    [
+      { label: "Yes", detail: "Copy built-in template folders into .inkwell/templates" },
+      { label: "No", detail: "Keep templates built-in (extension/global only)" },
+    ],
+    {
+      placeHolder: "Seed this workspace with bundled Inkwell templates?",
+    }
+  );
+
+  if (copyTemplates?.label === "Yes") {
+    const copiedTemplates = seedProjectTemplates(baseDir);
+    if (copiedTemplates.length) {
+      report.push(`copied templates: ${copiedTemplates.join(", ")}`);
+    } else {
+      report.push("template folders already present");
+    }
+  }
+
+  const gi = updateGitignore(baseDir);
+  if (gi.length) report.push(`updated .gitignore (${gi.length} entries)`);
+  if (copyGuide(baseDir)) report.push("updated .inkwell/guide.md");
+
+  if (report.length) {
+    vscode.window.showInformationMessage(
+      `Workspace bootstrap complete: ${report.join("; ")}.`
+    );
+  } else {
+    vscode.window.showInformationMessage(
+      "Workspace already contains a usable .inkwell setup."
+    );
+  }
 }
 
 function createStructure(opts: ScaffoldOptions): void {
@@ -447,7 +556,7 @@ export async function updateProject(): Promise<void> {
   const projectRoot = findInkwellRoot(editor.document.uri);
   if (!projectRoot) {
     vscode.window.showWarningMessage(
-      "No Inkwell project found. Run \"Inkwell: New Project\" first."
+      "No Inkwell project found. Run \"Inkwell: Bootstrap Workspace (.inkwell Folder)\" or \"Inkwell: New Project\" first."
     );
     return;
   }


### PR DESCRIPTION
## Summary
- add `Inkwell: Bootstrap Workspace (.inkwell Folder)` to create top-level `.inkwell` in repos that are not yet Inkwell projects
- expose the command when no project is detected (command palette + markdown/latex editor title)
- seed required workspace structure and optional bundled templates, and update non-project guidance in update flow

## Test plan
- [x] `npm run compile`
- [x] `npm run verify`
- [x] command registration and menu conditions reviewed in `package.json`
- [x] branch tested with pre-commit quality gates

Closes #43