### PR TITLE
docs: align install guidance with full LaTeX setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Inkwell lets you stay in markdown, stay in your editor, and still get publicatio
 
 ### 1. Install dependencies
 
+**Recommended (all platforms):**
+
+Run `Cmd+Shift+P` → **Inkwell: Check / Install Toolchain**. The guided installer now installs core tools plus the full LaTeX package set from `requirements-latex.txt` for Homebrew/TinyTeX flows.
+
 **macOS (Homebrew):**
 
 ```bash
@@ -42,7 +46,9 @@ npm install -g @mermaid-js/mermaid-cli
 Then install the LaTeX packages Inkwell's templates need (listed in [`requirements-latex.txt`](requirements-latex.txt)):
 
 ```bash
-sed 's/#.*//' requirements-latex.txt | xargs tlmgr install && texhash
+tlmgr update --self
+sed 's/#.*//' requirements-latex.txt | awk 'NF' | xargs tlmgr install
+texhash || mktexlsr
 ```
 
 **Linux:**
@@ -54,6 +60,14 @@ npm install -g @mermaid-js/mermaid-cli
 ```
 
 `pandoc-crossref` is required for `@fig:`, `@eq:`, and `@tbl:` cross-references. On Linux, install from [GitHub releases](https://github.com/lierdakil/pandoc-crossref/releases) or your package manager if available (`sudo apt install pandoc-crossref`).
+
+If `tlmgr` is available on your Linux TeX install, run the same full requirements pass:
+
+```bash
+sudo tlmgr update --self
+sed 's/#.*//' requirements-latex.txt | awk 'NF' | xargs sudo tlmgr install
+sudo texhash || sudo mktexlsr
+```
 
 **Python** (optional, for runnable `{python}` code blocks): set up per-project with `Cmd+Shift+P` > **Inkwell: Setup Python Environment**, or manually:
 

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -486,6 +486,7 @@ async function installWithPackageManager(status: ToolchainStatus): Promise<void>
   const hasDnf = fs.existsSync("/usr/bin/dnf");
 
   const commands: string[] = [];
+  const requiredPackages = uniquePackages(loadRequiredPackages());
 
   if (hasApt) {
     if (!status.pandoc.installed) {
@@ -511,6 +512,12 @@ async function installWithPackageManager(status: ToolchainStatus): Promise<void>
     terminal.sendText('echo "Neither apt nor dnf found. See TinyTeX or manual install options."');
     return;
   }
+
+  commands.push(
+    'if command -v tlmgr >/dev/null 2>&1; then sudo tlmgr update --self && ' +
+      buildTlmgrInstallCommand(requiredPackages, { useSudo: true }) +
+      '; else echo "tlmgr not found; distro TeX packages may be incomplete. Consider Inkwell: Install TinyTeX or install TeX Live full."; fi'
+  );
 
   terminal.sendText(commands.join(" && "));
 }
@@ -577,6 +584,7 @@ async function installTinyTeX(status: ToolchainStatus): Promise<void> {
 
 function showInstructions(status: ToolchainStatus): void {
   const doc: string[] = ["# Inkwell: Toolchain Setup\n"];
+  const reqFile = path.join(_extensionPath, "requirements-latex.txt");
 
   if (!status.pandoc.installed) {
     doc.push("## Pandoc\n");
@@ -635,7 +643,10 @@ function showInstructions(status: ToolchainStatus): void {
     doc.push("**Option B: TinyTeX (~100MB)**\n");
     doc.push("```bash");
     doc.push('curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh');
-    doc.push("tlmgr install collection-fontsrecommended xetex fontspec");
+    doc.push("tlmgr update --self");
+    doc.push('REQ="/path/to/requirements-latex.txt"');
+    doc.push('sed \'s/#.*//\' "$REQ" | awk \'NF\' | xargs tlmgr install');
+    doc.push("texhash || mktexlsr");
     doc.push("```\n");
     if (isMac) {
       doc.push("**Option C: Full MacTeX (~5GB)**\n");
@@ -656,6 +667,13 @@ function showInstructions(status: ToolchainStatus): void {
     doc.push(`tlmgr install ${status.missingPackages.join(" ")} && texhash`);
     doc.push("```\n");
   }
+
+  doc.push("## Install full Inkwell LaTeX requirements\n");
+  doc.push("```bash");
+  doc.push(`REQ="${reqFile}"`);
+  doc.push('sed \'s/#.*//\' "$REQ" | awk \'NF\' | xargs tlmgr install');
+  doc.push("texhash || mktexlsr");
+  doc.push("```\n");
 
   if (!status.mmdc.installed) {
     doc.push("## Mermaid CLI (optional, for diagrams in PDF)\n");


### PR DESCRIPTION
## Summary
- update toolchain setup guidance to include full requirements-latex install commands in the generated instructions
- extend apt/dnf setup path to attempt full `tlmgr` requirements provisioning when available
- refresh README install section to point users to the toolchain command and full package install snippets

## Test plan
- [x] `npm run compile`
- [x] `npm run verify`
- [x] manually reviewed README install commands for copy-paste correctness

Closes #47