### PR TITLE
fix: harden fresh-install setup and rho license handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.4 (2026-03-18)
+
+Installer guidance and docs now consistently point to full LaTeX dependency provisioning.
+
+- Updated toolchain setup instructions to include full `requirements-latex.txt` install commands
+- Extended Linux apt/dnf setup flow to attempt full `tlmgr` requirements install when available
+- Updated README install steps to recommend `Inkwell: Check / Install Toolchain` and include full package install snippets
+- Added `fixtounicode` to required LaTeX packages and corrected `extsizes` detection to check `extarticle.cls`
+
 ## 0.1.3 (2026-03-18)
 
 Toolchain setup now installs full LaTeX template dependencies more reliably.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inkwell",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inkwell",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/requirements-latex.txt
+++ b/requirements-latex.txt
@@ -66,6 +66,7 @@ units
 silence
 pbalance
 extsizes
+fixtounicode
 
 # bundles (provide multiple .sty files each)
 # amsfonts -> amssymb.sty, amsfonts.sty

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -58,7 +58,7 @@ const FALLBACK_PACKAGES = [
   "chemfig", "circuitikz",
   "supertabular", "matlab-prettifier", "lipsum", "hardwrap",
   "units", "silence",
-  "pbalance", "extsizes",
+  "pbalance", "extsizes", "fixtounicode",
   "amsfonts", "amscls", "tools", "preprint", "sttools",
   "graphics", "oberdiek", "psnfss",
   "mathpazo", "palatino", "bera", "soul", "stix2-type1", "tex-gyre",
@@ -212,6 +212,7 @@ async function checkLatexPackages(kpsewhich: string | undefined): Promise<string
     "graphics": "rotating.sty",
     "oberdiek": "iflang.sty",
     "psnfss": "helvet.sty",
+    "extsizes": "extarticle.cls",
   };
 
   const missing: string[] = [];
@@ -344,7 +345,7 @@ export async function showToolchainStatus(): Promise<void> {
 
     const buttons: string[] = [];
     if (isMac) {
-      buttons.push("Install with Homebrew");
+      buttons.push("Install Full MacTeX (recommended)", "Install with Homebrew");
     } else if (isLinux) {
       buttons.push("Install with apt/dnf");
     }
@@ -355,7 +356,9 @@ export async function showToolchainStatus(): Promise<void> {
       ...buttons
     );
 
-    if (choice === "Install with Homebrew") {
+    if (choice === "Install Full MacTeX (recommended)") {
+      await installFullMacTeX(status);
+    } else if (choice === "Install with Homebrew") {
       await installWithHomebrew(status);
     } else if (choice === "Install with apt/dnf") {
       await installWithPackageManager(status);
@@ -369,13 +372,17 @@ export async function showToolchainStatus(): Promise<void> {
 
   // Core tools present but packages missing
   if (missingCount > 0) {
+    const message = isMac
+      ? `${missingCount} LaTeX package${missingCount > 1 ? "s" : ""} missing: ${status.missingPackages.join(", ")}. Seeing errors like "File 'fixtounicode.sty' not found"? Install Full MacTeX for the most reliable setup.`
+      : `${missingCount} LaTeX package${missingCount > 1 ? "s" : ""} missing: ${status.missingPackages.join(", ")}`;
     const choice = await vscode.window.showWarningMessage(
-      `${missingCount} LaTeX package${missingCount > 1 ? "s" : ""} missing: ${status.missingPackages.join(", ")}`,
-      "Install now",
-      "Show details"
+      message,
+      ...(isMac ? ["Install Full MacTeX (recommended)", "Install now", "Show details"] : ["Install now", "Show details"])
     );
 
-    if (choice === "Install now") {
+    if (choice === "Install Full MacTeX (recommended)") {
+      await installFullMacTeX(status);
+    } else if (choice === "Install now") {
       await installMissingPackages(status.missingPackages);
     } else if (choice === "Show details") {
       showPackageDetails(status);
@@ -475,6 +482,33 @@ async function installWithHomebrew(status: ToolchainStatus): Promise<void> {
       '; else echo "tlmgr not found after install; restart terminal and run Inkwell setup again."; fi'
   );
 
+  terminal.sendText(commands.join(" && "));
+}
+
+async function installFullMacTeX(status: ToolchainStatus): Promise<void> {
+  const terminal = vscode.window.createTerminal("Inkwell Setup");
+  terminal.show();
+
+  const hasBrew = fs.existsSync("/opt/homebrew/bin/brew") ||
+    fs.existsSync("/usr/local/bin/brew");
+  if (!hasBrew) {
+    terminal.sendText('echo "Homebrew not found. Install from https://brew.sh first."');
+    return;
+  }
+
+  const commands: string[] = [];
+  const requiredPackages = uniquePackages(loadRequiredPackages());
+  if (!status.pandoc.installed) {
+    commands.push("brew install pandoc");
+  }
+  if (!status.crossref.installed) {
+    commands.push("brew install pandoc-crossref");
+  }
+  commands.push("brew install --cask mactex");
+  commands.push(
+    'eval "$(/usr/libexec/path_helper)" && sudo tlmgr update --self && ' +
+      buildTlmgrInstallCommand(requiredPackages, { useSudo: true })
+  );
   terminal.sendText(commands.join(" && "));
 }
 
@@ -585,6 +619,19 @@ async function installTinyTeX(status: ToolchainStatus): Promise<void> {
 function showInstructions(status: ToolchainStatus): void {
   const doc: string[] = ["# Inkwell: Toolchain Setup\n"];
   const reqFile = path.join(_extensionPath, "requirements-latex.txt");
+
+  if (isMac) {
+    doc.push("## Recommended for macOS (fewest package errors)\n");
+    doc.push("If you are seeing errors like \"File `fixtounicode.sty` not found\", install full MacTeX and then apply Inkwell's requirements list.\n");
+    doc.push("```bash");
+    doc.push("brew install pandoc pandoc-crossref");
+    doc.push("brew install --cask mactex");
+    doc.push("sudo tlmgr update --self");
+    doc.push(`REQ="${reqFile}"`);
+    doc.push("sed 's/#.*//' \"$REQ\" | awk 'NF' | xargs sudo tlmgr install");
+    doc.push("sudo texhash || sudo mktexlsr");
+    doc.push("```\n");
+  }
 
   if (!status.pandoc.installed) {
     doc.push("## Pandoc\n");

--- a/templates/rho/rho-class/rho.cls
+++ b/templates/rho/rho-class/rho.cls
@@ -245,7 +245,7 @@
             {\ifx\@accepted\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\acceptedlanguage}\@accepted\hspace{10pt}\fi}
             {\ifx\@published\undefined\else\textcolor{rhocolor}{\bfseries\ignorespaces\publishedlanguage}\@published\fi\par}
                 \vskip3pt
-            {\@license\par}
+            {\ifx\@license\undefined\else\@license\fi\par}
          \vskip1pt
         \rule{\textwidth}{0.3pt}
 }


### PR DESCRIPTION
## Summary
- add full MacTeX as the primary recommended macOS setup path in toolchain prompts and instructions
- include `fixtounicode` in required LaTeX package provisioning and map `extsizes` checks to `extarticle.cls`
- guard rho license rendering so missing `license` frontmatter no longer causes an undefined control sequence
- ship release metadata for `0.1.4`

## Test plan
- [x] `npm run compile`
- [x] `npm run verify`
- [x] regression check for template compile path and toolchain messaging updates

Closes #49