### PR TITLE
fix: Mermaid mmdc PATH for nvm, fnm, Volta + shell fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.6 (2026-03-19)
+
+PATH construction for subprocesses (Mermaid CLI, Pandoc/TeX) so **GUI-launched** VS Code/Cursor finds **`mmdc`** when Node tools live under **nvm**, **fnm**, or **Volta**.
+
+- Added `src/shell-env.ts`: `buildCodeBlockPath`, `buildTexInvocationPath`, `collectNodeToolBinDirs`, `findBinaryViaShell` (login-shell fallback; Windows `where`)
+- **`inject`**: dynamic `getInjectEnv()`, one-time shell resolution + prepend if `mmdc --version` fails; log PATH head to **Inkwell LaTeX** on failure
+- **`compiler`**: `TEX_ENV.PATH` uses `buildTexInvocationPath()` (same node-manager coverage, TeX-first order)
+- **`toolchain`**: search paths include `~/.npm-global/bin` + node-manager bins; **`mmdc`** probe uses shell fallback
+- **`inkwell-output`**: singleton output channel; **preview** uses it
+- **README**: VSIX smoke-test, troubleshooting for Node managers + output channel, packaging tip
+
 ## 0.1.5 (2026-03-19)
 
 Scaffold resources consolidated into `.inkwell/` for a cleaner project layout.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Inkwell lets you stay in markdown, stay in your editor, and still get publicatio
 Download the latest `.vsix` from [Releases](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases), then:
 
 ```bash
-cursor --install-extension inkwell-0.1.5.vsix --force
-# or: code --install-extension inkwell-0.1.5.vsix --force
+cursor --install-extension inkwell-0.1.6.vsix --force
+# or: code --install-extension inkwell-0.1.6.vsix --force
 ```
 
 Or in the editor: `Cmd+Shift+P` > **Extensions: Install from VSIX...** and select the file.
+
+**Verify a `.vsix` install (recommended):** `Cmd+Shift+P` > **Developer: Reload Window**. Then run **Inkwell: Check / Install Toolchain**, open a markdown file with `{mermaid}` blocks (e.g. `examples/demo-default.md`), run **Inkwell: Compile PDF**, and confirm `.inkwell/mermaid/` contains rendered images and the PDF shows diagrams—not raw mermaid source as code listings. That matches what end users get (a bundled extension with no dev-folder fallback).
 
 **Option B: Build from source**
 
@@ -42,7 +44,7 @@ npm run compile
 Then either:
 
 - **Install from folder** (development): `Cmd+Shift+P` > **Developer: Install Extension from Location...** > select the repo folder > reload the window.
-- **Package as .vsix**: `npm run package && npx @vscode/vsce package` > install the resulting `.vsix` as above.
+- **Package as .vsix**: `npm run package && npx @vscode/vsce package` > install the resulting `.vsix` as above. (`vscode:prepublish` runs `package` before publish, but run it locally too before `vsce package` so `out/extension.js` includes the latest bundle.)
 
 ### 2. Install the toolchain (Pandoc + LaTeX)
 
@@ -100,7 +102,11 @@ sudo texhash || sudo mktexlsr
 python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt
 ```
 
-> **Troubleshooting:** If compilation fails with `Missing file: foo.sty`, run `tlmgr install foo`. The build log (`Cmd+Shift+U` > **Inkwell LaTeX**) shows the exact missing filename. Mermaid blocks without `mmdc` installed render in the live preview but appear as code listings in PDFs.
+**Troubleshooting**
+
+- **Missing LaTeX packages:** If compilation fails with `Missing file: foo.sty`, run `tlmgr install foo`. The build log (`Cmd+Shift+U` > **Inkwell LaTeX**) shows the exact missing filename.
+- **Mermaid in PDF:** Diagram blocks need `mmdc` from `@mermaid-js/mermaid-cli` (e.g. `npm install -g @mermaid-js/mermaid-cli`). Without it, live preview may still show something useful, but **compiled PDFs** often leave mermaid as code listings and **`.inkwell/mermaid/`** stays empty.
+- **Cursor/VS Code launched from the Dock (Node managers):** GUI apps do not inherit your shell `PATH`. Inkwell augments `PATH` for subprocesses (Mermaid, Pandoc/TeX) with **`~/.npm-global/bin`**, **`nvm`** (`NVM_BIN`, **`~/.nvm/alias/default`**, and every **`~/.nvm/versions/node/<version>/bin`**), **`fnm`** (`FNM_MULTISHELL_PATH`), and **Volta** (`VOLTA_HOME` or **`~/.volta/bin`**). If `mmdc` is still missing, it runs a one-time **`SHELL -ilc`** resolution and prepends that directory for the session. Check **View → Output → Inkwell LaTeX** for a PATH diagnostic if **`mmdc --version`** fails. You can still install **`mmdc`** via **Homebrew** or symlink it into **`/opt/homebrew/bin`** if you prefer.
 
 ### 3. Bootstrap your workspace
 
@@ -725,9 +731,9 @@ All commands are available from the command palette (`Cmd+Shift+P` / `Ctrl+Shift
 | **Inkwell: Setup Python Environment** | | Create a venv and install from `requirements.txt` |
 | **Inkwell: Check / Install Toolchain** | | Verify Pandoc and XeLaTeX are installed, with guided setup if missing |
 
-**Tip:** If you are developing from source and rebuild the extension (`npm run compile`), reload the editor window with `Cmd+Shift+P` > **Developer: Reload Window** to pick up the changes. If you installed via `.vsix`, re-run `npm run package && npx @vscode/vsce package` and reinstall the `.vsix`.
+**Tip:** If you are developing from **folder** (`npm run compile` / watch), reload with `Cmd+Shift+P` > **Developer: Reload Window**. If you ship a **`.vsix`**, always **`npm run package`** (bundled `out/extension.js`) before `npx @vscode/vsce package`, then reinstall the `.vsix` and reload.
 
-**Contributor workflow:** Run `npm run verify` before opening a PR. The same check runs in GitHub Actions and in the local pre-commit hook, so commits and merges are gated on a passing typecheck + lint run.
+**Contributor workflow:** Run `npm run verify` before opening a PR (typecheck, ESLint, and template regressions via `scripts/check-template-regressions.mjs`). The same `verify` job runs in GitHub Actions on pushes and PRs to `main`, and the Husky **pre-commit** hook runs `npm run verify` after `npm install`.
 
 ## Settings
 
@@ -750,6 +756,12 @@ Inkwell includes a Cursor agent at `.cursor/agents/inkwell-guide.md`. When worki
 The agent references the full [Syntax Guide](guide.md) for field names, attribute tables, and conversion rules.
 
 ## Releases
+
+### [v0.1.6](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases/tag/v0.1.6) (March 19, 2026)
+
+PATH augmentation for **Mermaid (`mmdc`)** and TeX subprocesses when the editor is **GUI-launched** (no shell `PATH`): **nvm**, **fnm**, **Volta**, `~/.npm-global/bin`, plus a one-time login-shell fallback. Toolchain **mmdc** probe matches. README VSIX verification and troubleshooting updated.
+
+See the [CHANGELOG](CHANGELOG.md).
 
 ### [v0.1.5](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases/tag/v0.1.5) (March 19, 2026)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inkwell",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inkwell",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -16,6 +16,7 @@ import { InkwellDiagnostics, CompileError } from "./diagnostics";
 import { getTemplateForDocument, copySupportingFiles, PdfEngine, ResolvedTemplate, collectAllFeatures } from "./templates";
 import { prepareForCompilation } from "./inject";
 import { writePreambleFile } from "./preamble";
+import { buildTexInvocationPath } from "./shell-env";
 
 const exec = promisify(execFile);
 
@@ -34,34 +35,9 @@ const PANDOC_EXTENSIONS = [
   "smart",
 ].join("+");
 
-// VS Code child processes do not inherit the user's shell PATH, so TeX
-// binaries are invisible unless we reconstruct the search path ourselves.
-function buildTexPath(): string {
-  const base = ["/usr/local/bin", "/usr/bin"];
-  const home = os.homedir();
-  if (process.platform === "darwin") {
-    return [
-      "/Library/TeX/texbin",
-      "/opt/homebrew/bin",
-      `${home}/Library/TinyTeX/bin/universal-darwin`,
-      ...base,
-      process.env.PATH,
-    ].join(":");
-  }
-  return [
-    ...base,
-    `${home}/.TinyTeX/bin/x86_64-linux`,
-    `${home}/.TinyTeX/bin/aarch64-linux`,
-    "/usr/local/texlive/2024/bin/x86_64-linux",
-    "/usr/local/texlive/2025/bin/x86_64-linux",
-    "/usr/local/texlive/2026/bin/x86_64-linux",
-    process.env.PATH,
-  ].join(":");
-}
-
 const TEX_ENV = {
   ...process.env,
-  PATH: buildTexPath(),
+  PATH: buildTexInvocationPath(),
 };
 
 export interface CompileResult {

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -11,35 +11,37 @@
 
 import * as path from "path";
 import * as fs from "fs";
-import * as os from "os";
 import * as crypto from "crypto";
 import { execFileSync } from "child_process";
 import { BlockResult, CodeBlock, DisplayMode, parseCodeBlocks, parseRunConfig, RunConfig } from "./runner";
+import { buildCodeBlockPath, findBinaryViaShell } from "./shell-env";
+import { getInkwellOutputChannel } from "./inkwell-output";
 
-function buildShellPath(): string {
-  const base = ["/usr/local/bin", "/usr/bin"];
-  const home = os.homedir();
-  const npmGlobal = path.join(home, ".npm-global", "bin");
-  if (process.platform === "darwin") {
-    return [
-      "/opt/homebrew/bin",
-      npmGlobal,
-      `${home}/Library/TinyTeX/bin/universal-darwin`,
-      "/Library/TeX/texbin",
-      ...base,
-      process.env.PATH,
-    ].join(":");
-  }
-  return [
-    npmGlobal,
-    ...base,
-    `${home}/.TinyTeX/bin/x86_64-linux`,
-    `${home}/.TinyTeX/bin/aarch64-linux`,
-    process.env.PATH,
-  ].join(":");
+/** Session-local dirs prepended after `mmdc` is resolved via login shell. */
+const injectPathShellPrepends: string[] = [];
+let shellMmdcProbeDone = false;
+
+function getInjectPath(): string {
+  const base = buildCodeBlockPath();
+  if (!injectPathShellPrepends.length) return base;
+  return [...injectPathShellPrepends, base].join(":");
 }
 
-const INJECT_ENV = { ...process.env, PATH: buildShellPath() };
+function getInjectEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, PATH: getInjectPath() };
+}
+
+function tryAugmentMmdcFromShell(): void {
+  if (shellMmdcProbeDone) return;
+  shellMmdcProbeDone = true;
+  const resolved = findBinaryViaShell("mmdc");
+  if (resolved) {
+    const dir = path.dirname(resolved);
+    if (dir && !injectPathShellPrepends.includes(dir)) {
+      injectPathShellPrepends.push(dir);
+    }
+  }
+}
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".svg", ".pdf", ".eps"]);
 
@@ -487,13 +489,31 @@ function mmdcAvailable(): boolean {
   if (_mmdcAvailable !== undefined && Date.now() - _mmdcCheckTime < MMDC_CACHE_TTL) {
     return _mmdcAvailable;
   }
-  try {
+  const tryProbe = (): boolean => {
     execFileSync("mmdc", ["--version"], {
-      encoding: "utf-8", timeout: 5000, stdio: "pipe", env: INJECT_ENV,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: "pipe",
+      env: getInjectEnv(),
     });
+    return true;
+  };
+  try {
+    tryProbe();
     _mmdcAvailable = true;
   } catch {
-    _mmdcAvailable = false;
+    tryAugmentMmdcFromShell();
+    try {
+      tryProbe();
+      _mmdcAvailable = true;
+    } catch {
+      _mmdcAvailable = false;
+      const p = getInjectPath();
+      const head = p.split(":").slice(0, 8).join(":");
+      getInkwellOutputChannel().appendLine(
+        `[mermaid] mmdc not found or failed --version. PATH head (extension-constructed): ${head}${p.split(":").length > 8 ? " ..." : ""}`,
+      );
+    }
   }
   _mmdcCheckTime = Date.now();
   return _mmdcAvailable;
@@ -554,7 +574,7 @@ export function renderMermaidBlocks(markdown: string, workDir: string): string {
           cwd: workDir,
           timeout: 30_000,
           stdio: "pipe",
-          env: INJECT_ENV,
+          env: getInjectEnv(),
         });
         if (!fs.existsSync(svgPath)) {
           const alt = svgPath.replace(".svg", "-1.svg");
@@ -564,7 +584,7 @@ export function renderMermaidBlocks(markdown: string, workDir: string): string {
           cwd: workDir,
           timeout: 30_000,
           stdio: "pipe",
-          env: INJECT_ENV,
+          env: getInjectEnv(),
         });
         if (!fs.existsSync(pngPath)) {
           const alt = pngPath.replace(".png", "-1.png");

--- a/src/inkwell-output.ts
+++ b/src/inkwell-output.ts
@@ -1,0 +1,11 @@
+import * as vscode from "vscode";
+
+let channel: vscode.OutputChannel | undefined;
+
+/** Single "Inkwell LaTeX" output channel for compile logs and diagnostics. */
+export function getInkwellOutputChannel(): vscode.OutputChannel {
+  if (!channel) {
+    channel = vscode.window.createOutputChannel("Inkwell LaTeX");
+  }
+  return channel;
+}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -12,6 +12,7 @@ import { compile, detectMode, isCompilable } from "./compiler";
 import { InkwellDiagnostics } from "./diagnostics";
 import { parseCodeBlocks, BlockProgress } from "./runner";
 import { prepareForPreview } from "./inject";
+import { getInkwellOutputChannel } from "./inkwell-output";
 
 const md = new MarkdownIt({
   html: true,
@@ -26,14 +27,13 @@ export class InkwellPreviewProvider {
   private disposables: vscode.Disposable[] = [];
   private diagnostics: InkwellDiagnostics | undefined;
   private currentDocument: vscode.TextDocument | undefined;
-  private outputChannel: vscode.OutputChannel;
+  private outputChannel: vscode.OutputChannel = getInkwellOutputChannel();
   private initialized = false;
   private pdfCache: { path: string; mtimeMs: number; base64: string } | undefined;
   onRun?: () => Promise<void>;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
-    this.outputChannel = vscode.window.createOutputChannel("Inkwell LaTeX");
   }
 
   setDiagnostics(diagnostics: InkwellDiagnostics): void {

--- a/src/shell-env.ts
+++ b/src/shell-env.ts
@@ -1,0 +1,184 @@
+// Augmented PATH for child processes. GUI apps on macOS get a minimal PATH from
+// launchd; we replicate common dev locations (TeX, Homebrew, Node version
+// managers) so tools like mmdc and latexmk resolve reliably.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+
+/** nvm, fnm, Volta install dirs — user-specific and often missing from GUI PATH. */
+export function collectNodeToolBinDirs(): string[] {
+  const dirs: string[] = [];
+  const home = os.homedir();
+
+  const pushDir = (d: string) => {
+    if (!d || dirs.includes(d)) return;
+    try {
+      if (fs.statSync(d).isDirectory()) dirs.push(d);
+    } catch {
+      /* skip */
+    }
+  };
+
+  // nvm: active shell sets NVM_BIN
+  const nvmBin = process.env.NVM_BIN;
+  if (nvmBin) pushDir(nvmBin);
+
+  const nvmDir = process.env.NVM_DIR || path.join(home, ".nvm");
+  const defaultAliasFile = path.join(nvmDir, "alias", "default");
+  if (fs.existsSync(defaultAliasFile)) {
+    try {
+      const raw = fs.readFileSync(defaultAliasFile, "utf-8").trim();
+      // Skip indirection like lts/* — resolve only concrete version labels
+      if (raw && !raw.includes("*") && !raw.includes("/")) {
+        const withV = raw.startsWith("v") ? raw : `v${raw}`;
+        let candidate = path.join(nvmDir, "versions", "node", withV, "bin");
+        if (!fs.existsSync(candidate) && raw.startsWith("v")) {
+          candidate = path.join(nvmDir, "versions", "node", raw, "bin");
+        }
+        pushDir(candidate);
+      }
+    } catch {
+      /* unreadable alias */
+    }
+  }
+
+  const versionsDir = path.join(nvmDir, "versions", "node");
+  try {
+    if (fs.existsSync(versionsDir)) {
+      const versions = fs
+        .readdirSync(versionsDir)
+        .filter((n) => /^v\d/.test(n))
+        .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+      for (const v of versions) {
+        pushDir(path.join(versionsDir, v, "bin"));
+      }
+    }
+  } catch {
+    /* skip */
+  }
+
+  const fnmMultishell = process.env.FNM_MULTISHELL_PATH;
+  if (fnmMultishell) {
+    pushDir(path.join(fnmMultishell, "bin"));
+  }
+
+  const voltaHome = process.env.VOLTA_HOME || path.join(home, ".volta");
+  pushDir(path.join(voltaHome, "bin"));
+
+  return dirs;
+}
+
+function dedupePathSegments(segments: (string | undefined)[]): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const s of segments) {
+    if (!s || seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out.join(":");
+}
+
+/**
+ * PATH for Mermaid CLI, inline eval, and other subprocesses that should see
+ * the same Node/Homebrew layout as a typical developer shell.
+ */
+export function buildCodeBlockPath(): string {
+  const base = ["/usr/local/bin", "/usr/bin"];
+  const home = os.homedir();
+  const npmGlobal = path.join(home, ".npm-global", "bin");
+  const nodeTools = collectNodeToolBinDirs();
+
+  if (process.platform === "darwin") {
+    return dedupePathSegments([
+      "/opt/homebrew/bin",
+      npmGlobal,
+      ...nodeTools,
+      `${home}/Library/TinyTeX/bin/universal-darwin`,
+      "/Library/TeX/texbin",
+      ...base,
+      process.env.PATH,
+    ]);
+  }
+
+  return dedupePathSegments([
+    npmGlobal,
+    ...nodeTools,
+    ...base,
+    `${home}/.TinyTeX/bin/x86_64-linux`,
+    `${home}/.TinyTeX/bin/aarch64-linux`,
+    "/usr/local/texlive/2024/bin/x86_64-linux",
+    "/usr/local/texlive/2025/bin/x86_64-linux",
+    "/usr/local/texlive/2026/bin/x86_64-linux",
+    process.env.PATH,
+  ]);
+}
+
+/** PATH for Pandoc / XeLaTeX / pdfLaTeX runs (TeX-heavy order, plus Node shims). */
+export function buildTexInvocationPath(): string {
+  const base = ["/usr/local/bin", "/usr/bin"];
+  const home = os.homedir();
+  const npmGlobal = path.join(home, ".npm-global", "bin");
+  const nodeTools = collectNodeToolBinDirs();
+
+  if (process.platform === "darwin") {
+    return dedupePathSegments([
+      "/Library/TeX/texbin",
+      "/opt/homebrew/bin",
+      npmGlobal,
+      ...nodeTools,
+      `${home}/Library/TinyTeX/bin/universal-darwin`,
+      ...base,
+      process.env.PATH,
+    ]);
+  }
+
+  return dedupePathSegments([
+    ...base,
+    npmGlobal,
+    ...nodeTools,
+    `${home}/.TinyTeX/bin/x86_64-linux`,
+    `${home}/.TinyTeX/bin/aarch64-linux`,
+    "/usr/local/texlive/2024/bin/x86_64-linux",
+    "/usr/local/texlive/2025/bin/x86_64-linux",
+    "/usr/local/texlive/2026/bin/x86_64-linux",
+    process.env.PATH,
+  ]);
+}
+
+/**
+ * Last resort: ask the user's login shell where a binary lives (-il loads
+ * ~/.zshrc / profile hooks for nvm, fnm, etc.). Used when the constructed PATH
+ * still misses mmdc.
+ */
+export function findBinaryViaShell(binaryName: string): string | undefined {
+  if (process.platform === "win32") {
+    try {
+      const comspec = process.env.ComSpec || "cmd.exe";
+      const result = execFileSync(comspec, ["/d", "/s", "/c", `where ${binaryName}`], {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: "pipe",
+      });
+      const line = result.trim().split(/\r?\n/)[0]?.trim();
+      return line && fs.existsSync(line) ? line : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  try {
+    const shell = process.env.SHELL || (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash");
+    const result = execFileSync(shell, ["-ilc", `command -v ${binaryName} || which ${binaryName}`], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: "pipe",
+    });
+    const resolved = result.trim().split(/\r?\n/).pop()?.trim();
+    return resolved && fs.existsSync(resolved) ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -9,6 +9,7 @@ import { promisify } from "util";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { collectNodeToolBinDirs, findBinaryViaShell } from "./shell-env";
 
 const exec = promisify(execFile);
 
@@ -69,18 +70,23 @@ const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
 
 function searchPaths(): string[] {
+  const home = os.homedir();
+  const npmGlobal = path.join(home, ".npm-global", "bin");
+  const nodeBins = collectNodeToolBinDirs();
   const common = ["/usr/local/bin", "/usr/bin"];
   if (isMac) {
-    const home = os.homedir();
     return [
       "/opt/homebrew/bin",
+      npmGlobal,
+      ...nodeBins,
       ...common,
       "/Library/TeX/texbin",
       path.join(home, "Library/TinyTeX/bin/universal-darwin"),
     ];
   }
-  const home = os.homedir();
   return [
+    npmGlobal,
+    ...nodeBins,
     ...common,
     `${home}/bin`,
     `${home}/.TinyTeX/bin/x86_64-linux`,
@@ -120,6 +126,19 @@ async function probe(
       }
     }
   } catch {}
+
+  if (name === "mmdc") {
+    const p = findBinaryViaShell(name);
+    if (p && fs.existsSync(p)) {
+      try {
+        const { stdout } = await exec(p, ["--version"], { timeout: 5000 });
+        return { installed: true, version: stdout.split("\n")[0].trim(), path: p };
+      } catch {
+        return { installed: true, path: p };
+      }
+    }
+  }
+
   return { installed: false };
 }
 


### PR DESCRIPTION
## Summary
Implements **#53**: reliable `mmdc` discovery when VS Code/Cursor is launched from the Dock (minimal `PATH`).

### Code
- `src/shell-env.ts` — `buildCodeBlockPath`, `buildTexInvocationPath`, `collectNodeToolBinDirs` (nvm / fnm / Volta), `findBinaryViaShell`
- `src/inject.ts` — `getInjectEnv()`, session prepend after shell resolves `mmdc`, failure log to **Inkwell LaTeX**
- `src/compiler.ts` — `TEX_ENV` via `buildTexInvocationPath()`
- `src/toolchain.ts` — aligned search paths + `mmdc` shell fallback
- `src/inkwell-output.ts` + `preview.ts` — shared output channel

### Release
- **v0.1.6** — `package.json`, `CHANGELOG.md`, README install VSIX name + Releases section

### Checklist
- [x] `npm run verify`
- [x] `npm run package` / `vsce package` → `inkwell-0.1.6.vsix` (local artifact, not committed)

Closes #53