### PR TITLE
fix: single workspace .inkwell root for artifacts (v0.1.7)

### DIFF
--- a/.cursor/rules/extension-architecture.mdc
+++ b/.cursor/rules/extension-architecture.mdc
@@ -17,23 +17,24 @@ alwaysApply: true
 | `inject.ts` | Injects cached code outputs into markdown before compilation |
 | `preamble.ts` | Generates LaTeX preamble from `inkwell:` frontmatter options |
 | `cache.ts` | Code block output caching and invalidation |
-| `config.ts` | Project root detection, .bib discovery, defaults.yaml |
+| `config.ts` | Project root detection (`.inkwell/`), artifact paths, .bib discovery, defaults.yaml |
+| `shell-env.ts` | Augmented `PATH` for subprocesses (TeX, `mmdc`, node managers) |
 | `diagnostics.ts` | Error parsing, VS Code diagnostic reporting |
 | `scaffold.ts` | New project scaffolding (Inkwell: New Project command) |
 | `toolchain.ts` | Pandoc/TeX binary detection and guided installation |
 
 ## Key Conventions
 
-- Compilation always happens in an isolated temp directory (`getCacheDir`). The user's working tree is never written to except for the final PDF output.
-- `TEX_ENV` is constructed at module load with expanded PATH for TeX binaries. All `exec` calls for TeX/Pandoc use this environment, never bare `process.env`.
+- Compilation always happens in an isolated temp directory (`getCacheDir`). The user's working tree is never written to except for the final PDF output and Inkwell’s **project-root** `.inkwell/` dirs: `outputs/<doc-key>/`, `compiled/`, `mermaid/` (see `config.getInkwellProjectRoot`, `getInkwellOutputsDir`, `getInkwellCompiledPath`).
+- `TEX_ENV` uses `buildTexInvocationPath()` from `shell-env.ts`. All `exec` calls for TeX/Pandoc use this environment, never bare `process.env`.
 - Template selection flows: YAML frontmatter `template:` field > `.inkwell/manifest.json` > default "inkwell" template.
-- Code block outputs cache by content hash. A block only re-runs when its source changes.
+- Code block outputs cache by content hash under **per-document** subfolders. A block only re-runs when its source changes.
 
 ## Environment
 
 - TypeScript compiled to `out/` via `tsc`.
 - `__dirname` at runtime is `<extension-root>/out/`. Built-in templates live at `path.join(__dirname, "..", "templates")`.
-- VS Code on macOS does not inherit the user's shell PATH when launched from the Dock. `buildTexPath()` in `compiler.ts` adds common TeX locations explicitly.
+- VS Code on macOS does not inherit the user's shell PATH when launched from the Dock. `shell-env.ts` adds common TeX and Node-tool locations explicitly.
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.7 (2026-03-19)
+
+**Project root for all `.inkwell` artifacts** (fixes nested `.inkwell/` beside deep `.md` files).
+
+- Code block cache, Mermaid PNG/SVG, and injected `compiled` markdown now live under the **Inkwell project root** (first ancestor containing `.inkwell/`), not next to the source file.
+- Per-document paths: `.inkwell/outputs/<doc-key>/` and `.inkwell/compiled/<doc-key>.<ext>` where `<doc-key>` is the source path relative to the project (e.g. `examples--demo-default`).
+- Block `file="..."` resolution: try **document folder** first, then **project root** (so `.inkwell/scripts/…` works from nested markdown).
+- Code block **cwd** and Python env resolution prefer the project root; **Setup Python Env** `./.inkwell/venv` resolves to the project `.inkwell/`, not the document directory.
+- Preview webview **localResourceRoots** include the project root for mermaid/output assets.
+- Scaffold / gitignore: `.inkwell/compiled/` directory (replaces flat `compiled.*` ignore).
+
 ## 0.1.6 (2026-03-19)
 
 PATH construction for subprocesses (Mermaid CLI, Pandoc/TeX) so **GUI-launched** VS Code/Cursor finds **`mmdc`** when Node tools live under **nvm**, **fnm**, or **Volta**.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Inkwell lets you stay in markdown, stay in your editor, and still get publicatio
 Download the latest `.vsix` from [Releases](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases), then:
 
 ```bash
-cursor --install-extension inkwell-0.1.6.vsix --force
-# or: code --install-extension inkwell-0.1.6.vsix --force
+cursor --install-extension inkwell-0.1.7.vsix --force
+# or: code --install-extension inkwell-0.1.7.vsix --force
 ```
 
 Or in the editor: `Cmd+Shift+P` > **Extensions: Install from VSIX...** and select the file.
@@ -131,11 +131,11 @@ See the **[Syntax Guide](guide.md)** for the complete reference on YAML frontmat
 
 ## Project structure
 
-Everything Inkwell manages lives under `.inkwell/`, keeping your working tree clean:
+Everything Inkwell manages lives under **one** `.inkwell/` at the **Inkwell project root** (the first folder found when walking up from your `.md` file that contains `.inkwell/`—usually the repo root next to `.cursor/`). Nested markdown (e.g. `docs/chapter.md`) does **not** get a second `.inkwell/` beside the file.
 
 ```
 my-paper/
-  my-paper.md              # your document
+  my-paper.md              # your document (any path under the project root)
   requirements.txt         # Python dependencies (if enabled)
   venv/                    # Python environment (if enabled)
   .inkwell/
@@ -145,8 +145,9 @@ my-paper/
     figures/               # static images, diagrams
     references/            # .bib files
     examples/              # demo .md files for each template
-    outputs/               # cached code block results (gitignored)
-    mermaid/               # cached mermaid renders (gitignored)
+    outputs/               # per-document cache dirs (gitignored), e.g. outputs/my-paper/
+    compiled/              # injected markdown for Pandoc (gitignored), e.g. compiled/my-paper.md
+    mermaid/               # cached mermaid renders (gitignored, shared by hash)
     templates/             # project-local template overrides (optional)
   .gitignore
 ```
@@ -201,7 +202,7 @@ echo "Built on $(date)"
 | `label`   | Cross-reference label (produces `fig:label` or `tbl:label`) |
 | `cache`   | Set to `"false"` to re-run every time, skipping the content cache |
 
-Results cache in `.inkwell/outputs/`. Only re-run when the code actually changes.
+Results cache under `.inkwell/outputs/<document-key>/` (derived from each source file’s path relative to the project root). Only re-run when the code actually changes.
 
 ### Generated tables and figures
 
@@ -313,7 +314,7 @@ inkwell:
 
 ### Self-contained `.inkwell/` workspace
 
-All extension-managed resources live under a single `.inkwell/` directory: scripts, figures, references, examples, cached outputs, mermaid renders, and templates. Your project root stays clean — just your `.md` document files, a `.gitignore`, and optionally a Python venv. The scaffold creates the full structure automatically via **New Project** or **Bootstrap Workspace**, and the **Update Project** command backfills any missing directories or starter files.
+All extension-managed resources live under a single `.inkwell/` directory at the **project root**: scripts, figures, references, examples, per-document output caches (`.inkwell/outputs/<doc-key>/`), compiled staging (`.inkwell/compiled/`), shared mermaid cache, and templates. Markdown can live in subfolders; with a **single-folder workspace** opened at the repo root, Inkwell uses that root’s `.inkwell/` (not a nested `.inkwell` next to the file). **Multi-Inkwell monorepos:** open each subproject as its own workspace folder (multi-root), or only the root that should own `.inkwell/`. The scaffold creates the full structure via **New Project** or **Bootstrap Workspace**, and **Update Project** backfills missing directories.
 
 ## Templates
 
@@ -756,6 +757,10 @@ Inkwell includes a Cursor agent at `.cursor/agents/inkwell-guide.md`. When worki
 The agent references the full [Syntax Guide](guide.md) for field names, attribute tables, and conversion rules.
 
 ## Releases
+
+### [v0.1.7](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases/tag/v0.1.7) (March 19, 2026)
+
+Single **project-root** `.inkwell/` for outputs, mermaid, and compiled staging (with per-document subfolders). Prefers the **workspace folder** when it contains `.inkwell/` so nested stray folders don’t take over. See [CHANGELOG](CHANGELOG.md).
 
 ### [v0.1.6](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases/tag/v0.1.6) (March 19, 2026)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inkwell",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inkwell",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,6 +7,7 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import { CodeBlock } from "./runner";
+import { resolveBlockFilePath } from "./config";
 
 export interface BlockCacheEntry {
   hash: string;
@@ -36,11 +37,11 @@ export function saveCache(cacheDir: string, cache: BlockCache): void {
   fs.writeFileSync(file, JSON.stringify(cache, null, 2), "utf-8");
 }
 
-export function getBlockHash(block: CodeBlock, workDir: string): string {
+export function getBlockHash(block: CodeBlock, docDir: string, projectRoot: string): string {
   const h = crypto.createHash("sha256");
 
   if (block.file) {
-    const resolved = path.resolve(workDir, block.file);
+    const resolved = resolveBlockFilePath(block.file, docDir, projectRoot);
     try {
       h.update(fs.readFileSync(resolved));
     } catch {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import * as crypto from "crypto";
 
 export interface InkwellManifest {
   name?: string;
@@ -46,6 +47,80 @@ export function findInkwellRoot(
     dir = path.dirname(dir);
   }
   return undefined;
+}
+
+/**
+ * Inkwell project root for artifacts (`outputs/`, `mermaid/`, `compiled/`) and
+ * code-block cwd. Prefers the **VS Code workspace folder** when it contains
+ * `.inkwell/` and the file lies under that folder—so a single repo root next
+ * to `.cursor/` wins over a stray nested `.inkwell/` beside a deep `.md` file.
+ * Otherwise falls back to `findInkwellRoot` (walk upward). If none matches,
+ * uses the document's directory.
+ */
+export function getInkwellProjectRoot(sourcePath: string): string {
+  const uri = vscode.Uri.file(sourcePath);
+  const normalized = path.normalize(sourcePath);
+  const folder = vscode.workspace.getWorkspaceFolder(uri);
+  if (folder) {
+    const wsRoot = folder.uri.fsPath;
+    const underWs =
+      normalized === wsRoot || normalized.startsWith(wsRoot + path.sep);
+    if (underWs && fs.existsSync(path.join(wsRoot, ".inkwell"))) {
+      return wsRoot;
+    }
+  }
+  return findInkwellRoot(uri) ?? path.dirname(normalized);
+}
+
+/**
+ * Stable subdirectory name under `.inkwell/outputs/` (and compiled filename
+ * stem) derived from the source path relative to the project root.
+ */
+export function getInkwellDocumentKey(
+  sourceFile: string,
+  projectRoot: string,
+): string {
+  let rel = path.relative(projectRoot, sourceFile);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    const h = crypto.createHash("sha256").update(sourceFile).digest("hex").slice(0, 16);
+    return `__ext_${h}`;
+  }
+  rel = rel.replace(/\\/g, "/");
+  const ext = path.extname(rel);
+  const without = ext ? rel.slice(0, -ext.length) : rel;
+  const key = without.replace(/\//g, "--");
+  return key || "__root";
+}
+
+/** Per-document code-block cache: `.inkwell/outputs/<key>/` */
+export function getInkwellOutputsDir(sourceFile: string): string {
+  const projectRoot = getInkwellProjectRoot(sourceFile);
+  const key = getInkwellDocumentKey(sourceFile, projectRoot);
+  return path.join(projectRoot, ".inkwell", "outputs", key);
+}
+
+/** Injected markdown for Pandoc: `.inkwell/compiled/<key>.<ext>` */
+export function getInkwellCompiledPath(sourceFile: string): string {
+  const projectRoot = getInkwellProjectRoot(sourceFile);
+  const key = getInkwellDocumentKey(sourceFile, projectRoot);
+  const ext = path.extname(sourceFile) || ".md";
+  return path.join(projectRoot, ".inkwell", "compiled", `${key}${ext}`);
+}
+
+/**
+ * Resolve `file="..."` on code blocks: document-relative first, then project
+ * root (so `.inkwell/scripts/foo.py` works from nested markdown paths).
+ */
+export function resolveBlockFilePath(
+  fileRel: string,
+  docDir: string,
+  projectRoot: string,
+): string {
+  const fromDoc = path.normalize(path.resolve(docDir, fileRel));
+  if (fs.existsSync(fromDoc)) return fromDoc;
+  const fromRoot = path.normalize(path.resolve(projectRoot, fileRel));
+  if (fs.existsSync(fromRoot)) return fromRoot;
+  return fromDoc;
 }
 
 export function loadManifest(projectRoot: string): InkwellManifest {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { InkwellPreviewProvider } from "./preview";
 import { compile, exportPDF, isCompilable } from "./compiler";
 import { InkwellDiagnostics } from "./diagnostics";
 import { selectTemplateCommand } from "./templates";
-import { findInkwellRoot, saveManifestField } from "./config";
+import { findInkwellRoot, getInkwellOutputsDir, getInkwellProjectRoot, saveManifestField } from "./config";
 import { checkToolchain, showToolchainStatus, setExtensionPath } from "./toolchain";
 import { runAllBlocks, parseCodeBlocks, RunCancellation } from "./runner";
 import { clearCache } from "./cache";
@@ -107,8 +107,7 @@ export function activate(context: vscode.ExtensionContext) {
       const doc =
         vscode.window.activeTextEditor?.document ?? previewProvider.getDocument();
       if (!doc) return;
-      const sourceDir = path.dirname(doc.uri.fsPath);
-      const cacheDir = path.join(sourceDir, ".inkwell", "outputs");
+      const cacheDir = getInkwellOutputsDir(doc.uri.fsPath);
       clearCache(cacheDir);
       vscode.window.showInformationMessage("Inkwell: Code block cache cleared.");
     }),
@@ -277,10 +276,11 @@ async function runCodeBlocksWithProgress(
 
 async function setupPythonEnv(document: vscode.TextDocument): Promise<void> {
   const docDir = path.dirname(document.uri.fsPath);
+  const projectRoot = getInkwellProjectRoot(document.uri.fsPath);
 
   const envOptions = [
     { label: "./venv", detail: "Create venv in document directory" },
-    { label: "./.inkwell/venv", detail: "Create venv in .inkwell project directory" },
+    { label: "./.inkwell/venv", detail: "Create venv under project .inkwell/ (workspace root)" },
     { label: "Custom path...", detail: "Specify a custom venv location" },
   ];
 
@@ -301,9 +301,22 @@ async function setupPythonEnv(document: vscode.TextDocument): Promise<void> {
     envPath = pick.label;
   }
 
-  const resolved = path.resolve(docDir, envPath);
-  const reqFile = path.join(docDir, "requirements.txt");
-  const hasReqs = fs.existsSync(reqFile);
+  let resolved: string;
+  if (path.isAbsolute(envPath)) {
+    resolved = envPath;
+  } else {
+    const rel = envPath.replace(/\\/g, "/").replace(/^\.\//, "");
+    if (rel.startsWith(".inkwell/")) {
+      resolved = path.normalize(path.join(projectRoot, rel));
+    } else {
+      resolved = path.resolve(docDir, envPath);
+    }
+  }
+
+  const reqFile = [path.join(docDir, "requirements.txt"), path.join(projectRoot, "requirements.txt")].find((p) =>
+    fs.existsSync(p)
+  );
+  const hasReqs = Boolean(reqFile);
 
   const terminal = vscode.window.createTerminal("Inkwell Python Env");
   terminal.show();
@@ -318,7 +331,7 @@ async function setupPythonEnv(document: vscode.TextDocument): Promise<void> {
 
   commands.push(`source "${resolved}/bin/activate"`);
 
-  if (hasReqs) {
+  if (hasReqs && reqFile) {
     commands.push(`pip install -r "${reqFile}"`);
   } else {
     const installPick = await vscode.window.showInputBox({

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -16,6 +16,12 @@ import { execFileSync } from "child_process";
 import { BlockResult, CodeBlock, DisplayMode, parseCodeBlocks, parseRunConfig, RunConfig } from "./runner";
 import { buildCodeBlockPath, findBinaryViaShell } from "./shell-env";
 import { getInkwellOutputChannel } from "./inkwell-output";
+import {
+  getInkwellCompiledPath,
+  getInkwellOutputsDir,
+  getInkwellProjectRoot,
+  resolveBlockFilePath,
+} from "./config";
 
 /** Session-local dirs prepended after `mmdc` is resolved via login shell. */
 const injectPathShellPrepends: string[] = [];
@@ -109,7 +115,8 @@ export function injectResults(
   markdown: string,
   results: BlockResult[],
   defaultDisplay: DisplayMode = "output",
-  workDir?: string,
+  docDir: string,
+  projectRoot: string,
 ): string {
   if (!results.length) return markdown;
 
@@ -132,7 +139,7 @@ export function injectResults(
     const start = output.indexOf(block.raw, offset);
     if (start === -1) continue;
 
-    const replacement = buildBlockOutput(block, result, display, workDir);
+    const replacement = buildBlockOutput(block, result, display, docDir, projectRoot);
 
     output =
       output.substring(0, start) +
@@ -148,11 +155,12 @@ function buildBlockOutput(
   block: CodeBlock,
   result: BlockResult | undefined,
   display: DisplayMode,
-  workDir?: string,
+  docDir: string,
+  projectRoot: string,
 ): string {
   if (display === "none") return "";
 
-  const codeSection = formatCodeBlock(block, workDir);
+  const codeSection = formatCodeBlock(block, docDir, projectRoot);
   const outputSection = result && result.exitCode === 0
     ? buildOutputContent(result) : null;
 
@@ -169,10 +177,10 @@ function pandocLang(lang: string): string {
   return PANDOC_LANG_MAP[lower] || lower;
 }
 
-function formatCodeBlock(block: CodeBlock, workDir?: string): string {
+function formatCodeBlock(block: CodeBlock, docDir: string, projectRoot: string): string {
   const lang = pandocLang(block.lang);
   if (block.file) {
-    const filePath = workDir ? path.resolve(workDir, block.file) : block.file;
+    const filePath = resolveBlockFilePath(block.file, docDir, projectRoot);
     let source: string;
     try {
       source = fs.readFileSync(filePath, "utf-8").trim();
@@ -328,8 +336,7 @@ export function gatherCachedResults(
   markdown: string,
   sourceFile: string,
 ): BlockResult[] {
-  const workDir = path.dirname(sourceFile);
-  const cacheDir = path.join(workDir, ".inkwell", "outputs");
+  const cacheDir = getInkwellOutputsDir(sourceFile);
 
   const blocks = parseCodeBlocks(markdown);
   const results: BlockResult[] = [];
@@ -369,13 +376,16 @@ export function gatherCachedResults(
 
 const INLINE_EXPR_RE = /`\{python\}\s+([^`]+)`/g;
 
-function resolvePython(runConfig: RunConfig, workDir: string): string {
+function resolvePython(runConfig: RunConfig, docDir: string, projectRoot: string): string {
   const envSpec = runConfig.pythonEnv;
   if (envSpec) {
-    const resolved = path.resolve(workDir, envSpec.replace(/^~/, process.env.HOME || "~"));
-    for (const bin of ["bin/python3", "bin/python"]) {
-      const full = path.join(resolved, bin);
-      if (fs.existsSync(full)) return full;
+    const home = process.env.HOME || "~";
+    for (const base of [projectRoot, docDir]) {
+      const resolved = path.resolve(base, envSpec.replace(/^~/, home));
+      for (const bin of ["bin/python3", "bin/python"]) {
+        const full = path.join(resolved, bin);
+        if (fs.existsSync(full)) return full;
+      }
     }
   }
   return "python3";
@@ -385,7 +395,8 @@ export function evaluateInlineExpressions(
   markdown: string,
   vars: Map<string, string>,
   runConfig: RunConfig,
-  workDir: string,
+  docDir: string,
+  projectRoot: string,
   cacheDir: string,
 ): string {
   const matches: { full: string; expr: string }[] = [];
@@ -435,12 +446,12 @@ export function evaluateInlineExpressions(
   const scriptPath = path.join(evalDir, "eval.py");
   fs.writeFileSync(scriptPath, script, "utf-8");
 
-  const python = resolvePython(runConfig, workDir);
+  const python = resolvePython(runConfig, docDir, projectRoot);
 
   let stdout: string;
   try {
     stdout = execFileSync(python, ["-u", scriptPath], {
-      cwd: workDir,
+      cwd: projectRoot,
       timeout: 30_000,
       encoding: "utf-8",
       env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
@@ -530,7 +541,8 @@ function parseMermaidAttrs(raw: string | undefined): Record<string, string> {
   return attrs;
 }
 
-export function renderMermaidBlocks(markdown: string, workDir: string): string {
+/** `projectRoot` — Inkwell project directory containing `.inkwell/` (not the `.md` folder when nested). */
+export function renderMermaidBlocks(markdown: string, projectRoot: string): string {
   if (!mmdcAvailable()) return markdown;
 
   const matches: { raw: string; attrsStr?: string; source: string }[] = [];
@@ -541,7 +553,7 @@ export function renderMermaidBlocks(markdown: string, workDir: string): string {
   }
   if (!matches.length) return markdown;
 
-  const mermaidDir = path.join(workDir, ".inkwell", "mermaid");
+  const mermaidDir = path.join(projectRoot, ".inkwell", "mermaid");
   fs.mkdirSync(mermaidDir, { recursive: true });
 
   let output = markdown;
@@ -571,7 +583,7 @@ export function renderMermaidBlocks(markdown: string, workDir: string): string {
       fs.writeFileSync(inputPath, match.source, "utf-8");
       try {
         execFileSync("mmdc", ["-i", inputPath, "-o", svgPath], {
-          cwd: workDir,
+          cwd: projectRoot,
           timeout: 30_000,
           stdio: "pipe",
           env: getInjectEnv(),
@@ -581,7 +593,7 @@ export function renderMermaidBlocks(markdown: string, workDir: string): string {
           if (fs.existsSync(alt)) fs.renameSync(alt, svgPath);
         }
         execFileSync("mmdc", ["-i", inputPath, "-o", pngPath, "-s", "4"], {
-          cwd: workDir,
+          cwd: projectRoot,
           timeout: 30_000,
           stdio: "pipe",
           env: getInjectEnv(),
@@ -630,11 +642,12 @@ export function prepareForCompilation(
   markdown: string,
   sourceFile: string,
 ): { injected: string; tempFile: string } {
-  const workDir = path.dirname(sourceFile);
+  const docDir = path.dirname(sourceFile);
+  const projectRoot = getInkwellProjectRoot(sourceFile);
 
   const hasMermaid = /^```(?:\{mermaid|mermaid)/m.test(markdown);
   const processed = hasMermaid
-    ? renderMermaidBlocks(markdown, workDir)
+    ? renderMermaidBlocks(markdown, projectRoot)
     : markdown;
 
   const blocks = parseCodeBlocks(processed);
@@ -651,14 +664,13 @@ export function prepareForCompilation(
   const results = gatherCachedResults(processed, sourceFile);
   const vars = collectVariables(results);
 
-  let injected = injectResults(processed, results, defaultDisplay, workDir);
+  let injected = injectResults(processed, results, defaultDisplay, docDir, projectRoot);
   injected = substituteVariables(injected, vars);
 
-  const cacheDir = path.join(workDir, ".inkwell", "outputs");
-  injected = evaluateInlineExpressions(injected, vars, runConfig, workDir, cacheDir);
+  const cacheDir = getInkwellOutputsDir(sourceFile);
+  injected = evaluateInlineExpressions(injected, vars, runConfig, docDir, projectRoot, cacheDir);
 
-  const ext = path.extname(sourceFile);
-  const tempFile = path.join(workDir, ".inkwell", `compiled${ext}`);
+  const tempFile = getInkwellCompiledPath(sourceFile);
   fs.mkdirSync(path.dirname(tempFile), { recursive: true });
   fs.writeFileSync(tempFile, injected, "utf-8");
 
@@ -681,17 +693,18 @@ export function prepareForPreview(
 
   if (!hasBlocks && !hasVarRefs && !hasInlineExprs) return processed;
 
-  const workDir = path.dirname(sourceFile);
+  const docDir = path.dirname(sourceFile);
+  const projectRoot = getInkwellProjectRoot(sourceFile);
   const runConfig = parseRunConfig(processed);
   const defaultDisplay = runConfig.defaultDisplay || "output";
   const results = gatherCachedResults(processed, sourceFile);
   const vars = collectVariables(results);
 
-  let injected = injectResults(processed, results, defaultDisplay, workDir);
+  let injected = injectResults(processed, results, defaultDisplay, docDir, projectRoot);
   injected = substituteVariables(injected, vars);
 
-  const cacheDir = path.join(workDir, ".inkwell", "outputs");
-  injected = evaluateInlineExpressions(injected, vars, runConfig, workDir, cacheDir);
+  const cacheDir = getInkwellOutputsDir(sourceFile);
+  injected = evaluateInlineExpressions(injected, vars, runConfig, docDir, projectRoot, cacheDir);
 
   return injected;
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -13,6 +13,7 @@ import { InkwellDiagnostics } from "./diagnostics";
 import { parseCodeBlocks, BlockProgress } from "./runner";
 import { prepareForPreview } from "./inject";
 import { getInkwellOutputChannel } from "./inkwell-output";
+import { getInkwellOutputsDir, getInkwellProjectRoot } from "./config";
 
 const md = new MarkdownIt({
   html: true,
@@ -95,8 +96,9 @@ export class InkwellPreviewProvider {
     }
 
     const docDir = path.dirname(editor.document.uri.fsPath);
-
-    const inkwellOutputDir = path.join(docDir, ".inkwell", "outputs");
+    const sourceFile = editor.document.uri.fsPath;
+    const projectRoot = getInkwellProjectRoot(sourceFile);
+    const inkwellOutputDir = getInkwellOutputsDir(sourceFile);
 
     this.panel = vscode.window.createWebviewPanel(
       "inkwellPreview",
@@ -107,6 +109,7 @@ export class InkwellPreviewProvider {
         localResourceRoots: [
           vscode.Uri.file(path.join(this.context.extensionPath, "media")),
           vscode.Uri.file(docDir),
+          vscode.Uri.file(projectRoot),
           vscode.Uri.file(inkwellOutputDir),
         ],
         retainContextWhenHidden: true,
@@ -172,12 +175,16 @@ export class InkwellPreviewProvider {
   private updateResourceRoots(document: vscode.TextDocument): void {
     if (!this.panel) return;
     const docDir = path.dirname(document.uri.fsPath);
+    const sourceFile = document.uri.fsPath;
+    const projectRoot = getInkwellProjectRoot(sourceFile);
+    const outputsDir = getInkwellOutputsDir(sourceFile);
     (this.panel as any).webview.options = {
       ...this.panel.webview.options,
       localResourceRoots: [
         vscode.Uri.file(path.join(this.context.extensionPath, "media")),
         vscode.Uri.file(docDir),
-        vscode.Uri.file(path.join(docDir, ".inkwell", "outputs")),
+        vscode.Uri.file(projectRoot),
+        vscode.Uri.file(outputsDir),
       ],
     };
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { execFile, ChildProcess } from "child_process";
 import { getBlockHash, loadCache, saveCache } from "./cache";
+import { getInkwellOutputsDir, getInkwellProjectRoot, resolveBlockFilePath } from "./config";
 
 export class RunCancellation {
   private _cancelled = false;
@@ -195,7 +196,8 @@ function resolveInterpreter(
   langKey: string,
   envPath: string | undefined,
   runConfig: RunConfig,
-  workDir: string,
+  projectRoot: string,
+  docDir: string,
 ): ResolvedInterpreter {
   const defaults = LANG_COMMANDS[langKey];
   if (!defaults) return { cmd: langKey, args: [], envVars: {}, label: langKey };
@@ -211,7 +213,17 @@ function resolveInterpreter(
     return { cmd: defaultCmd, args: defaultArgs, envVars: {}, label: defaultCmd };
   }
 
-  const resolved = path.resolve(workDir, envSpec.replace(/^~/, process.env.HOME || "~"));
+  const home = process.env.HOME || "~";
+  const spec = envSpec.replace(/^~/, home);
+  let resolved: string | undefined;
+  for (const base of [projectRoot, docDir]) {
+    const r = path.resolve(base, spec);
+    if (fs.existsSync(r)) {
+      resolved = r;
+      break;
+    }
+  }
+  if (!resolved) resolved = path.resolve(projectRoot, spec);
 
   if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
     const isPython = langKey.startsWith("python") || langKey === "python3";
@@ -258,8 +270,10 @@ function resolveInterpreter(
 
   let warning = `Environment "${envSpec}" not found at ${resolved}. Using system ${defaultCmd}. Run "Inkwell: Setup Python Env" to create it.`;
   if (langKey.startsWith("python")) {
-    const reqFile = path.join(workDir, "requirements.txt");
-    if (fs.existsSync(reqFile)) {
+    const reqFile = [path.join(docDir, "requirements.txt"), path.join(projectRoot, "requirements.txt")].find((p) =>
+      fs.existsSync(p)
+    );
+    if (reqFile) {
       warning += ` Found requirements.txt at ${reqFile}; run setup from this document folder and choose "${envSpec}" to auto-install dependencies.`;
     }
   }
@@ -273,7 +287,8 @@ function resolveInterpreter(
 
 export async function runBlock(
   block: CodeBlock,
-  workDir: string,
+  projectRoot: string,
+  docDir: string,
   outputDir: string,
   cancel?: RunCancellation,
   runConfig?: RunConfig,
@@ -299,7 +314,7 @@ export async function runBlock(
   let scriptPath: string;
 
   if (block.file) {
-    scriptPath = path.resolve(workDir, block.file);
+    scriptPath = resolveBlockFilePath(block.file, docDir, projectRoot);
     if (!fs.existsSync(scriptPath)) {
       return {
         block, stdout: "", stderr: `File not found: ${block.file}`,
@@ -315,7 +330,7 @@ export async function runBlock(
     fs.writeFileSync(scriptPath, block.source, "utf-8");
   }
 
-  const interp = resolveInterpreter(langKey, block.env, runConfig || {}, workDir);
+  const interp = resolveInterpreter(langKey, block.env, runConfig || {}, projectRoot, docDir);
 
   const env = {
     ...process.env,
@@ -333,7 +348,7 @@ export async function runBlock(
 
   try {
     const proc = execFile(cmd, args, {
-      cwd: workDir,
+      cwd: projectRoot,
       timeout: 300_000,
       env,
       maxBuffer: 10 * 1024 * 1024,
@@ -424,8 +439,9 @@ export async function runAllBlocks(
   const blocks = parseCodeBlocks(markdown);
   if (!blocks.length) return [];
 
-  const workDir = path.dirname(sourceFile);
-  const cacheDir = path.join(workDir, ".inkwell", "outputs");
+  const docDir = path.dirname(sourceFile);
+  const projectRoot = getInkwellProjectRoot(sourceFile);
+  const cacheDir = getInkwellOutputsDir(sourceFile);
   fs.mkdirSync(cacheDir, { recursive: true });
 
   const runConfig = parseRunConfig(markdown);
@@ -446,7 +462,7 @@ export async function runAllBlocks(
       continue;
     }
 
-    const hash = getBlockHash(block, workDir);
+    const hash = getBlockHash(block, docDir, projectRoot);
     const blockDir = path.join(cacheDir, `block_${block.index}`);
     const cached = cache.blocks[block.index];
 
@@ -477,7 +493,7 @@ export async function runAllBlocks(
 
     const t0 = Date.now();
     fs.mkdirSync(blockDir, { recursive: true });
-    const result = await runBlock(block, workDir, blockDir, cancel, runConfig);
+    const result = await runBlock(block, projectRoot, docDir, blockDir, cancel, runConfig);
     const elapsed = Date.now() - t0;
 
     const status: BlockStatus = cancel?.cancelled ? "cancelled"

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -37,7 +37,7 @@ inkwell:
 `;
 
 const GITIGNORE = `.inkwell/outputs/
-.inkwell/compiled.*
+.inkwell/compiled/
 .inkwell/mermaid/
 *.aux
 *.log
@@ -410,7 +410,7 @@ export async function bootstrapWorkspaceInkwell(): Promise<void> {
   const report: string[] = [];
   const inkwellDir = path.join(baseDir, ".inkwell");
   const bootstrapDirs = [
-    "outputs", "templates", "scripts", "figures", "references", "examples",
+    "outputs", "compiled", "templates", "scripts", "figures", "references", "examples",
   ];
   const manifestPath = path.join(inkwellDir, "manifest.json");
 
@@ -468,6 +468,7 @@ function createStructure(opts: ScaffoldOptions): void {
   const dirs = [
     ".inkwell",
     ".inkwell/outputs",
+    ".inkwell/compiled",
     ".inkwell/scripts",
     ".inkwell/figures",
     ".inkwell/references",
@@ -561,7 +562,15 @@ Write your content here. Cite sources with [@knuth1984] and use inline math like
 
 const GITIGNORE_LINES = GITIGNORE.split("\n").map((l) => l.trim()).filter(Boolean);
 
-const REQUIRED_DIRS = [".inkwell", ".inkwell/outputs", ".inkwell/scripts", ".inkwell/figures", ".inkwell/references", ".inkwell/examples"];
+const REQUIRED_DIRS = [
+  ".inkwell",
+  ".inkwell/outputs",
+  ".inkwell/compiled",
+  ".inkwell/scripts",
+  ".inkwell/figures",
+  ".inkwell/references",
+  ".inkwell/examples",
+];
 
 const STARTER_FILES: Array<{ rel: string; content: string }> = [
   { rel: ".inkwell/scripts/sine_plot.py", content: SINE_PLOT_PY },


### PR DESCRIPTION
## Summary
Routes **code-block cache**, **Mermaid**, and **compiled** staging through one **Inkwell project root** (workspace folder with `.inkwell/` when applicable), not `dirname(sourceFile)`.

### How this closes #55
| Before | After |
|--------|--------|
| Artifacts under nested paths like `docs/.inkwell/` | Artifacts under **repo** `<root>/.inkwell/` |
| Nested stray `.inkwell` could dominate | **Workspace folder** wins when it has `.inkwell/` |
| `file=".inkwell/scripts/x"` broke from subdirs | Resolve **doc dir** then **project root** |

### Implementation highlights
- `config.ts`: `getInkwellProjectRoot`, `getInkwellDocumentKey`, `getInkwellOutputsDir`, `getInkwellCompiledPath`, `resolveBlockFilePath`
- `inject.ts`, `runner.ts`, `cache.ts`, `extension.ts`, `preview.ts`, `scaffold.ts`
- README + `extension-architecture.mdc`; **CHANGELOG** `0.1.7`

### Release
- Version **0.1.7** in `package.json`
- After merge: `vsce package` → attach **inkwell-0.1.7.vsix** to GitHub Release `v0.1.7`

### Checklist
- [x] `npm run verify`

Closes #55