### PR TITLE
fix(stability): harden command flow and add verification gates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Bundle extension
+        run: npm run package
+
       - name: Verify
         run: npm run verify

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,14 @@
+.git/**
+.github/**
+src/**
+scripts/**
+node_modules/**
+venv/**
+tsconfig.json
+eslint.config.mjs
+*.vsix
+out/**/*.map
+.cursor/**
+!.cursor/
+!.cursor/agents/
+!.cursor/agents/inkwell-guide.md

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
         "category": "Inkwell"
       },
       {
+        "command": "inkwell.installPackage",
+        "title": "Inkwell: Install LaTeX Package",
+        "category": "Inkwell"
+      },
+      {
         "command": "inkwell.runCodeBlocks",
         "title": "Inkwell: Run Code Blocks",
         "category": "Inkwell"
@@ -205,7 +210,8 @@
     "package": "esbuild src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify",
     "lint": "eslint src --ext ts",
     "test:regressions": "node scripts/check-template-regressions.mjs",
-    "verify": "npm run typecheck && npm run lint && npm run test:regressions"
+    "test:stability": "node scripts/check-shortcuts-and-commands.mjs",
+    "verify": "npm run typecheck && npm run lint && npm run test:regressions && npm run test:stability"
   },
   "dependencies": {
     "markdown-it": "^14.1.0"

--- a/scripts/check-shortcuts-and-commands.mjs
+++ b/scripts/check-shortcuts-and-commands.mjs
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const packageJsonPath = path.join(repoRoot, "package.json");
+const extensionTsPath = path.join(repoRoot, "src", "extension.ts");
+
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const extensionSource = fs.readFileSync(extensionTsPath, "utf8");
+
+const commands = pkg?.contributes?.commands ?? [];
+const keybindings = pkg?.contributes?.keybindings ?? [];
+const editorTitleMenus = pkg?.contributes?.menus?.["editor/title"] ?? [];
+
+const commandIds = new Set(commands.map((c) => c.command));
+const registeredCommandMatches = extensionSource.matchAll(/registerCommand\("([^"]+)"/g);
+const registeredCommandIds = new Set(Array.from(registeredCommandMatches, (m) => m[1]));
+
+const failures = [];
+
+for (const kb of keybindings) {
+  if (!commandIds.has(kb.command)) {
+    failures.push(`keybinding command missing from contributes.commands: ${kb.command}`);
+  }
+  if (!registeredCommandIds.has(kb.command)) {
+    failures.push(`keybinding command missing from extension registration: ${kb.command}`);
+  }
+}
+
+for (const menuItem of editorTitleMenus) {
+  if (!commandIds.has(menuItem.command)) {
+    failures.push(`editor/title command missing from contributes.commands: ${menuItem.command}`);
+  }
+  if (!registeredCommandIds.has(menuItem.command)) {
+    failures.push(`editor/title command missing from extension registration: ${menuItem.command}`);
+  }
+}
+
+const previewKb = keybindings.find((k) => k.command === "inkwell.preview");
+const compileKb = keybindings.find((k) => k.command === "inkwell.compile");
+const runKb = keybindings.find((k) => k.command === "inkwell.runCodeBlocks");
+
+if (!previewKb || previewKb.when !== "editorLangId == markdown || editorLangId == latex") {
+  failures.push("inkwell.preview keybinding when-clause must be markdown or latex");
+}
+if (!compileKb || compileKb.when !== "editorLangId == markdown || editorLangId == latex") {
+  failures.push("inkwell.compile keybinding when-clause must be markdown or latex");
+}
+if (!runKb || runKb.when !== "editorLangId == markdown") {
+  failures.push("inkwell.runCodeBlocks keybinding when-clause must be markdown only");
+}
+
+if (!commandIds.has("inkwell.installPackage")) {
+  failures.push("inkwell.installPackage missing from contributes.commands");
+}
+if (!registeredCommandIds.has("inkwell.installPackage")) {
+  failures.push("inkwell.installPackage missing from extension registration");
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`FAIL: ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Shortcut and command stability checks passed.");

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -449,7 +449,12 @@ async function compilePandoc(
 
   const crossref = await findBinary("pandoc-crossref");
   if (crossref) {
-    args.splice(args.indexOf("--citeproc"), 0, "--filter", crossref);
+    const citeprocIndex = args.indexOf("--citeproc");
+    if (citeprocIndex >= 0) {
+      args.splice(citeprocIndex, 0, "--filter", crossref);
+    } else {
+      args.push("--filter", crossref);
+    }
   }
 
   const bibFiles = findBibFiles(projectRoot);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { compile, exportPDF, isCompilable } from "./compiler";
 import { InkwellDiagnostics } from "./diagnostics";
 import { selectTemplateCommand } from "./templates";
 import { findInkwellRoot, getInkwellOutputsDir, getInkwellProjectRoot, saveManifestField } from "./config";
-import { checkToolchain, showToolchainStatus, setExtensionPath } from "./toolchain";
+import { checkToolchain, installLatexPackage, showToolchainStatus, setExtensionPath } from "./toolchain";
 import { runAllBlocks, parseCodeBlocks, RunCancellation } from "./runner";
 import { clearCache } from "./cache";
 import { bootstrapWorkspaceInkwell, initProject, updateProject } from "./scaffold";
@@ -18,6 +18,8 @@ import * as fs from "fs";
 let diagnostics: InkwellDiagnostics;
 let autoCompileTimer: ReturnType<typeof setInterval> | undefined;
 let activeRunCancel: RunCancellation | undefined;
+let compileInFlight = false;
+let queuedCompile: vscode.TextDocument | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
   setExtensionPath(context.extensionPath);
@@ -85,6 +87,18 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand("inkwell.setupToolchain", () => {
       showToolchainStatus();
+    }),
+
+    vscode.commands.registerCommand("inkwell.installPackage", async (pkg?: string) => {
+      let packageName = pkg?.trim();
+      if (!packageName) {
+        packageName = await vscode.window.showInputBox({
+          prompt: "LaTeX package name to install via tlmgr",
+          placeHolder: "e.g. booktabs",
+        });
+      }
+      if (!packageName) return;
+      await installLatexPackage(packageName);
     }),
 
     vscode.commands.registerCommand("inkwell.runCodeBlocks", async () => {
@@ -196,22 +210,39 @@ function setupAutoCompileTimer(): void {
 }
 
 async function runCompile(document: vscode.TextDocument): Promise<void> {
+  if (compileInFlight) {
+    queuedCompile = document;
+    return;
+  }
+
+  compileInFlight = true;
+  let current: vscode.TextDocument | undefined = document;
+
   try {
-    const result = await compile(document);
-    diagnostics.report(document.uri, result.errors);
-    if (result.success && result.pdfPath) {
-      vscode.window.setStatusBarMessage(
-        `Inkwell: PDF compiled (${result.duration.toFixed(1)}s)`,
-        5000
-      );
-    } else if (result.errors.length > 0) {
-      vscode.window.setStatusBarMessage(
-        `Inkwell: ${result.errors.length} error(s)`,
-        5000
-      );
+    while (current) {
+      queuedCompile = undefined;
+      try {
+        const result = await compile(current);
+        diagnostics.report(current.uri, result.errors);
+        if (result.success && result.pdfPath) {
+          vscode.window.setStatusBarMessage(
+            `Inkwell: PDF compiled (${result.duration.toFixed(1)}s)`,
+            5000
+          );
+        } else if (result.errors.length > 0) {
+          vscode.window.setStatusBarMessage(
+            `Inkwell: ${result.errors.length} error(s)`,
+            5000
+          );
+        }
+      } catch (err) {
+        console.error("Inkwell compile error:", err);
+      }
+      current = queuedCompile;
     }
-  } catch (err) {
-    console.error("Inkwell compile error:", err);
+  } finally {
+    compileInFlight = false;
+    queuedCompile = undefined;
   }
 }
 
@@ -238,40 +269,48 @@ async function runCodeBlocksWithProgress(
 
   previewProvider.sendRunStarted(blocks.length);
 
-  const results = await runAllBlocks(text, sourceFile, cancel, (p) => {
-    previewProvider.sendBlockProgress(p);
-    if (p.warning) {
-      previewProvider.sendLogEntry("error", p.warning);
+  let results: Awaited<ReturnType<typeof runAllBlocks>> = [];
+  let threw = false;
+  try {
+    results = await runAllBlocks(text, sourceFile, cancel, (p) => {
+      previewProvider.sendBlockProgress(p);
+      if (p.warning) {
+        previewProvider.sendLogEntry("error", p.warning);
+      }
+      if (p.interpreter && p.status === "running") {
+        previewProvider.sendLogEntry("info", `Block ${p.index + 1}: using ${p.interpreter}`);
+      }
+    });
+  } catch (err) {
+    threw = true;
+    previewProvider.sendLogEntry("error", "Run failed unexpectedly", String(err));
+  } finally {
+    activeRunCancel = undefined;
+    const failed = results.filter((r) => r.exitCode !== 0 && r.exitCode !== 130);
+    const cancelled = results.filter((r) => r.exitCode === 130);
+    const cached = results.filter((r) => r.cached);
+    const ran = results.length - cached.length - cancelled.length;
+
+    for (const r of failed) {
+      previewProvider.sendLogEntry(
+        "error",
+        `Block ${r.block.index + 1} (${r.block.lang}) failed`,
+        r.stderr,
+      );
     }
-    if (p.interpreter && p.status === "running") {
-      previewProvider.sendLogEntry("info", `Block ${p.index + 1}: using ${p.interpreter}`);
+
+    if (threw) {
+      previewProvider.sendRunComplete("failed", ran, cached.length, cancelled.length, failed.length || 1);
+    } else if (cancel.cancelled) {
+      previewProvider.sendRunComplete("cancelled", ran, cached.length, cancelled.length);
+    } else if (failed.length) {
+      previewProvider.sendRunComplete("failed", ran, cached.length, 0, failed.length);
+    } else {
+      previewProvider.sendRunComplete("done", ran, cached.length);
     }
-  });
 
-  activeRunCancel = undefined;
-
-  const failed = results.filter((r) => r.exitCode !== 0 && r.exitCode !== 130);
-  const cancelled = results.filter((r) => r.exitCode === 130);
-  const cached = results.filter((r) => r.cached);
-  const ran = results.length - cached.length - cancelled.length;
-
-  for (const r of failed) {
-    previewProvider.sendLogEntry(
-      "error",
-      `Block ${r.block.index + 1} (${r.block.lang}) failed`,
-      r.stderr,
-    );
+    previewProvider.notifyBlocksRan();
   }
-
-  if (cancel.cancelled) {
-    previewProvider.sendRunComplete("cancelled", ran, cached.length, cancelled.length);
-  } else if (failed.length) {
-    previewProvider.sendRunComplete("failed", ran, cached.length, 0, failed.length);
-  } else {
-    previewProvider.sendRunComplete("done", ran, cached.length);
-  }
-
-  previewProvider.notifyBlocksRan();
 }
 
 async function setupPythonEnv(document: vscode.TextDocument): Promise<void> {

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -71,6 +71,7 @@ export function collectVariables(results: BlockResult[]): Map<string, string> {
   const vars = new Map<string, string>();
 
   for (const r of results) {
+    if (r.cacheStatus === "miss") continue;
     if (r.exitCode !== 0) continue;
 
     for (const line of r.stdout.split("\n")) {
@@ -343,6 +344,7 @@ export function gatherCachedResults(
 
   for (const block of blocks) {
     const blockDir = path.join(cacheDir, `block_${block.index}`);
+    const hasBlockDir = fs.existsSync(blockDir);
     let stdout = "";
     try {
       stdout = fs.readFileSync(path.join(blockDir, "stdout.txt"), "utf-8");
@@ -359,13 +361,17 @@ export function gatherCachedResults(
       }
     } catch {}
 
+    const cacheStatus: "hit" | "miss" =
+      hasBlockDir && (stdout.trim().length > 0 || artifacts.size > 0) ? "hit" : "miss";
+
     results.push({
       block,
       stdout,
       stderr: "",
       exitCode: 0,
       artifacts,
-      cached: true,
+      cached: cacheStatus === "hit",
+      cacheStatus,
     });
   }
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -31,6 +31,8 @@ export class InkwellPreviewProvider {
   private outputChannel: vscode.OutputChannel = getInkwellOutputChannel();
   private initialized = false;
   private pdfCache: { path: string; mtimeMs: number; base64: string } | undefined;
+  private compileInFlight = false;
+  private compileQueued = false;
   onRun?: () => Promise<void>;
 
   constructor(context: vscode.ExtensionContext) {
@@ -328,71 +330,86 @@ export class InkwellPreviewProvider {
   }
 
   private async handleCompile(): Promise<void> {
-    const doc = this.currentDocument;
-    if (!this.panel || !doc) return;
+    if (!this.panel || !this.currentDocument) return;
+    if (this.compileInFlight) {
+      this.compileQueued = true;
+      return;
+    }
 
-    this.panel.webview.postMessage({ type: "compileStarted" });
-
+    this.compileInFlight = true;
     try {
-      const result = await compile(doc);
+      do {
+        this.compileQueued = false;
+        const doc = this.currentDocument;
+        if (!this.panel || !doc) break;
 
-      this.outputChannel.clear();
-      this.outputChannel.appendLine(`Inkwell compile: ${doc.uri.fsPath}`);
-      this.outputChannel.appendLine(
-        `Result: ${result.success ? "success" : "failed"} (${result.duration.toFixed(1)}s)`
-      );
-      if (result.errors.length) {
-        this.outputChannel.appendLine(`\n--- Errors (${result.errors.length}) ---`);
-        for (const err of result.errors) {
-          const loc = err.line ? `line ${err.line}` : "unknown location";
-          this.outputChannel.appendLine(`  [${err.severity}] ${loc}: ${err.message}`);
+        this.panel.webview.postMessage({ type: "compileStarted" });
+
+        try {
+          const result = await compile(doc);
+
+          this.outputChannel.clear();
+          this.outputChannel.appendLine(`Inkwell compile: ${doc.uri.fsPath}`);
+          this.outputChannel.appendLine(
+            `Result: ${result.success ? "success" : "failed"} (${result.duration.toFixed(1)}s)`
+          );
+          if (result.errors.length) {
+            this.outputChannel.appendLine(`\n--- Errors (${result.errors.length}) ---`);
+            for (const err of result.errors) {
+              const loc = err.line ? `line ${err.line}` : "unknown location";
+              this.outputChannel.appendLine(`  [${err.severity}] ${loc}: ${err.message}`);
+            }
+          }
+          if (result.log.trim()) {
+            this.outputChannel.appendLine("\n--- Full Log ---");
+            this.outputChannel.appendLine(result.log);
+          }
+
+          if (this.diagnostics) {
+            this.diagnostics.report(doc.uri, result.errors);
+          }
+
+          if (result.success && result.pdfPath && this.panel) {
+            const pdfData = fs.readFileSync(result.pdfPath).toString("base64");
+            this.panel.webview.postMessage({
+              type: "compileDone",
+              pdfData,
+              duration: result.duration,
+              errors: [],
+              log: "",
+            });
+            const warnings = result.errors.filter(e => e.severity === "warning");
+            for (const w of warnings) {
+              const loc = w.line ? `line ${w.line}: ` : "";
+              this.sendLogEntry("warn", `${loc}${w.message}`);
+            }
+          } else if (this.panel) {
+            this.panel.webview.postMessage({
+              type: "compileDone",
+              pdfUri: null,
+              duration: result.duration,
+              errors: result.errors.map((e) => {
+                const loc = e.line ? `Line ${e.line}: ` : "";
+                return `${loc}${e.message}`;
+              }),
+              log: result.log,
+            });
+          }
+        } catch (err) {
+          if (this.panel) {
+            this.panel.webview.postMessage({
+              type: "compileDone",
+              pdfData: null,
+              duration: 0,
+              errors: [String(err)],
+              log: "",
+            });
+          }
         }
-      }
-      if (result.log.trim()) {
-        this.outputChannel.appendLine("\n--- Full Log ---");
-        this.outputChannel.appendLine(result.log);
-      }
-
-      if (this.diagnostics) {
-        this.diagnostics.report(doc.uri, result.errors);
-      }
-
-      if (result.success && result.pdfPath && this.panel) {
-        const pdfData = fs.readFileSync(result.pdfPath).toString("base64");
-        this.panel.webview.postMessage({
-          type: "compileDone",
-          pdfData,
-          duration: result.duration,
-          errors: [],
-          log: "",
-        });
-        const warnings = result.errors.filter(e => e.severity === "warning");
-        for (const w of warnings) {
-          const loc = w.line ? `line ${w.line}: ` : "";
-          this.sendLogEntry("warn", `${loc}${w.message}`);
-        }
-      } else if (this.panel) {
-        this.panel.webview.postMessage({
-          type: "compileDone",
-          pdfUri: null,
-          duration: result.duration,
-          errors: result.errors.map((e) => {
-            const loc = e.line ? `Line ${e.line}: ` : "";
-            return `${loc}${e.message}`;
-          }),
-          log: result.log,
-        });
-      }
-    } catch (err) {
-      if (this.panel) {
-        this.panel.webview.postMessage({
-          type: "compileDone",
-          pdfData: null,
-          duration: 0,
-          errors: [String(err)],
-          log: "",
-        });
-      }
+      } while (this.compileQueued);
+    } finally {
+      this.compileInFlight = false;
+      this.compileQueued = false;
     }
   }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -81,6 +81,7 @@ export interface BlockResult {
   exitCode: number;
   artifacts: Map<string, string>;
   cached: boolean;
+  cacheStatus?: "hit" | "miss";
   interpreter?: string;
   warning?: string;
 }
@@ -480,7 +481,7 @@ export async function runAllBlocks(
 
       results.push({
         block, stdout, stderr: "", exitCode: 0,
-        artifacts, cached: true,
+        artifacts, cached: true, cacheStatus: "hit",
       });
       continue;
     }

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -430,6 +430,18 @@ async function installMissingPackages(packages: string[]): Promise<void> {
   terminal.sendText(cmd);
 }
 
+export async function installLatexPackage(packageName: string): Promise<void> {
+  const normalized = packageName.trim();
+  if (!normalized) return;
+  if (!/^[A-Za-z0-9._-]+$/.test(normalized)) {
+    vscode.window.showErrorMessage(
+      `Invalid package name "${normalized}". Use letters, numbers, dot, underscore, or hyphen.`,
+    );
+    return;
+  }
+  await installMissingPackages([normalized]);
+}
+
 function showPackageDetails(status: ToolchainStatus): void {
   const doc: string[] = ["# Inkwell: LaTeX Package Status\n"];
 


### PR DESCRIPTION
## Summary
- harden extension stability by wiring `inkwell.installPackage`, adding run cleanup via `try/finally`, and adding queue-latest compile behavior for repeated compile triggers
- add compiler/cache safety guards (`pandoc-crossref` insertion fallback, explicit cache hit/miss metadata)
- add release safety checks with `.vscodeignore`, CI bundling (`npm run package`), and a shortcut-command integrity regression script in `npm run verify`

Closes #57

## Test plan
- [x] `npm run verify`
- [x] `npm run package`
- [ ] Manual shortcut matrix in VS Code (`cmd+shift+v`, `cmd+shift+r`, `cmd+shift+b` in markdown/latex contexts)
- [x] Commit hook verify checks pass
- [ ] `pre-commit run --all-files` (blocked, `.pre-commit-config.yaml` not present in repo)