### PR TITLE
feat(setup): add one-command macOS installer path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,42 @@ Inkwell lets you stay in markdown, stay in your editor, and still get publicatio
 
 ### 1. Install the extension
 
-**Option A: Install a pre-built .vsix** (recommended)
+**Option A: Extension marketplace (recommended)**
+
+Install directly from the extension store:
+
+```bash
+cursor --install-extension measure-one.inkwell --force
+# or: code --install-extension measure-one.inkwell --force
+```
+
+Or in the editor extensions pane, search for **Inkwell** and install.
+
+**Option B: One-command macOS setup (no sub-menus)**
+
+From the repo root:
+
+```bash
+./scripts/install-inkwell-macos.sh
+```
+
+This script installs:
+
+- `measure-one.inkwell` from the extension marketplace (via `cursor` or `code` CLI)
+- `pandoc` and `pandoc-crossref`
+- MacTeX (full install by default, or `--basictex`)
+- Mermaid CLI (`@mermaid-js/mermaid-cli`)
+- required LaTeX packages from `requirements-latex.txt` when `tlmgr` is available
+
+Examples:
+
+```bash
+./scripts/install-inkwell-macos.sh --basictex
+./scripts/install-inkwell-macos.sh --editor=cursor
+./scripts/install-inkwell-macos.sh --editor=code
+```
+
+**Option C: Install a pre-built .vsix**
 
 Download the latest `.vsix` from [Releases](https://github.com/goldberg-consulting/measured.one.inkwell-extension/releases), then:
 
@@ -30,9 +65,7 @@ cursor --install-extension inkwell-0.1.9.vsix --force
 
 Or in the editor: `Cmd+Shift+P` > **Extensions: Install from VSIX...** and select the file.
 
-**Verify a `.vsix` install (recommended):** `Cmd+Shift+P` > **Developer: Reload Window**. Then run **Inkwell: Check / Install Toolchain**, open a markdown file with `{mermaid}` blocks (e.g. `examples/demo-default.md`), run **Inkwell: Compile PDF**, and confirm `.inkwell/mermaid/` contains rendered images and the PDF shows diagrams—not raw mermaid source as code listings. That matches what end users get (a bundled extension with no dev-folder fallback).
-
-**Option B: Build from source**
+**Option D: Build from source**
 
 ```bash
 git clone https://github.com/goldberg-consulting/measured.one.inkwell-extension.git

--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
     "lint": "eslint src --ext ts",
     "test:regressions": "node scripts/check-template-regressions.mjs",
     "test:stability": "node scripts/check-shortcuts-and-commands.mjs",
-    "verify": "npm run typecheck && npm run lint && npm run test:regressions && npm run test:stability"
+    "test:installer": "bash -n scripts/install-inkwell-macos.sh",
+    "verify": "npm run typecheck && npm run lint && npm run test:regressions && npm run test:stability && npm run test:installer"
   },
   "dependencies": {
     "markdown-it": "^14.1.0"

--- a/scripts/install-inkwell-macos.sh
+++ b/scripts/install-inkwell-macos.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTENSION_ID="measure-one.inkwell"
+EDITOR_CLI="auto"
+TEX_DIST="mactex"
+
+for arg in "$@"; do
+  case "$arg" in
+    --editor=cursor) EDITOR_CLI="cursor" ;;
+    --editor=code) EDITOR_CLI="code" ;;
+    --editor=auto) EDITOR_CLI="auto" ;;
+    --basictex) TEX_DIST="basictex" ;;
+    *)
+      echo "Unknown argument: $arg"
+      echo "Usage: $0 [--editor=auto|cursor|code] [--basictex]"
+      exit 1
+      ;;
+  esac
+done
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This installer is for macOS only."
+  echo "For Linux setup, follow README instructions."
+  exit 1
+fi
+
+if ! has_cmd brew; then
+  echo "Homebrew is required. Install it first from https://brew.sh"
+  exit 1
+fi
+
+if ! has_cmd npm; then
+  echo "npm is required for Mermaid CLI. Install Node.js first."
+  exit 1
+fi
+
+if [[ "$EDITOR_CLI" == "auto" ]]; then
+  if has_cmd cursor; then
+    EDITOR_CLI="cursor"
+  elif has_cmd code; then
+    EDITOR_CLI="code"
+  else
+    EDITOR_CLI=""
+  fi
+fi
+
+echo "Installing toolchain with Homebrew..."
+brew install pandoc pandoc-crossref
+if [[ "$TEX_DIST" == "basictex" ]]; then
+  brew install --cask basictex
+else
+  brew install --cask mactex
+fi
+
+echo "Installing Mermaid CLI..."
+npm install -g @mermaid-js/mermaid-cli
+
+if [[ -n "$EDITOR_CLI" ]]; then
+  echo "Installing extension from marketplace with $EDITOR_CLI..."
+  "$EDITOR_CLI" --install-extension "$EXTENSION_ID" --force
+else
+  echo "Could not find cursor or code CLI."
+  echo "Install extension manually from the extension marketplace:"
+  echo "  $EXTENSION_ID"
+fi
+
+export PATH="/Library/TeX/texbin:$HOME/Library/TinyTeX/bin/universal-darwin:$PATH"
+
+REQ_FILE=""
+if [[ -f "./requirements-latex.txt" ]]; then
+  REQ_FILE="./requirements-latex.txt"
+elif [[ -f "$(cd "$(dirname "$0")/.." && pwd)/requirements-latex.txt" ]]; then
+  REQ_FILE="$(cd "$(dirname "$0")/.." && pwd)/requirements-latex.txt"
+fi
+
+if has_cmd tlmgr && [[ -n "$REQ_FILE" ]]; then
+  echo "Installing LaTeX requirements from $REQ_FILE..."
+  tlmgr update --self
+  sed 's/#.*//' "$REQ_FILE" | awk 'NF' | xargs tlmgr install
+  texhash || mktexlsr
+else
+  echo "Skipping tlmgr package pass (tlmgr or requirements file not found)."
+fi
+
+echo ""
+echo "Inkwell setup complete."
+echo "Next steps:"
+echo "1) Reload Cursor/VS Code."
+echo "2) Open Command Palette and run: Inkwell: Check / Install Toolchain"
+echo "3) Open a markdown file and test shortcuts:"
+echo "   Cmd+Shift+V (preview), Cmd+Shift+R (compile), Cmd+Shift+B (run code blocks)"


### PR DESCRIPTION
## Summary
- add `scripts/install-inkwell-macos.sh` to provide a one-command macOS setup path with Homebrew toolchain install and marketplace extension install
- update README installation flow to prioritize extension-store install and the one-command script (no submenu-heavy flow)
- add installer syntax validation (`test:installer`) to `npm run verify`

Closes #61

## Test plan
- [x] `npm run verify`
- [x] `python3 -m pre_commit run --all-files`
- [x] `bash -n scripts/install-inkwell-macos.sh` (via `npm run test:installer`)