### PR TITLE
ci: add release workflow with automated tap bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify
+        run: npm run verify
+
+      - name: Build VSIX
+        run: npx @vscode/vsce package --no-dependencies
+
+      - name: Extract version from package.json
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload VSIX to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VSIX="inkwell-${{ steps.version.outputs.version }}.vsix"
+          if [ -f "$VSIX" ]; then
+            gh release upload "${{ github.event.release.tag_name }}" "$VSIX" --clobber
+          else
+            echo "VSIX not found: $VSIX"
+            exit 1
+          fi
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          VSIX="inkwell-${{ steps.version.outputs.version }}.vsix"
+          SHA=$(shasum -a 256 "$VSIX" | awk '{print $1}')
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Update Homebrew tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "HOMEBREW_TAP_TOKEN secret not set; skipping tap update."
+            exit 0
+          fi
+
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.sha.outputs.sha256 }}"
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/goldberg-consulting/homebrew-inkwell.git" /tmp/tap
+          cd /tmp/tap
+
+          CASK="Casks/inkwell.rb"
+
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" "$CASK"
+          sed -i "s/sha256 \".*\"/sha256 \"${SHA}\"/" "$CASK"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CASK"
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "bump inkwell to ${VERSION}"
+          git push origin main


### PR DESCRIPTION
## Summary
- add `.github/workflows/release.yml` triggered on release publish
- builds VSIX, runs verify, uploads VSIX to the release, computes sha256
- clones `goldberg-consulting/homebrew-inkwell`, updates `Casks/inkwell.rb` with new version and sha256, pushes
- gracefully skips the tap update if `HOMEBREW_TAP_TOKEN` secret is not set

Closes #67

## Setup required
Add a repository secret `HOMEBREW_TAP_TOKEN` with a PAT that has `repo` scope for `goldberg-consulting/homebrew-inkwell`.

## Test plan
- [x] `npm run verify`
- [x] Workflow YAML is valid (checked with `actionlint` locally)
- [ ] Create a test release to verify end-to-end (requires secret to be set first)