### PR TITLE
fix(rho): eliminate excess whitespace around tables (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2 (2026-04-17)
+
+- **Rho template: reduce table whitespace.** The v0.2.1 fix eliminated the infinite-page loop on tall tables by wrapping every `longtable` in `\onecolumn` / `\twocolumn`, which forced a full column flush before and after each table. On documents with many tables this left large empty regions and inflated page count (40 pages for the 1000-line reference document, most of it blank). The revised approach redirects `longtable` to `\begin{table*}[!tbp]` + `\tabular`, a two-column-spanning float with flexible placement. LaTeX's float mechanism then places each table at the top, bottom, or on a dedicated float page, whichever fits. Same reference document now compiles to 18 pages with no infinite-loop risk.
+
 ## 0.2.1 (2026-04-17)
 
 - **Rho template: fix infinite-loop compile on tall tables.** The previous `longtable` redefinition forced every table into `\begin{table}[H]` + `\tabular`. Tables that did not fit on a page silently overflowed the output routine and sent xelatex into an unbounded page loop (`xdvipdfmx:fatal: Page number 65536 too large`), typically after a minute or more of apparent hang. The replacement wraps the original `longtable` in a `\onecolumn` / `\twocolumn` switch so page-breaking works inside rho's twocolumn layout. Compile for a 1000-line document with 17 longtables drops from unbounded to under 10 seconds.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/templates/rho/rho.latex
+++ b/templates/rho/rho.latex
@@ -55,34 +55,43 @@ $endif$
 $if(keywords)$\keywords{$keywords$}$endif$
 
 % Pandoc longtable handling. rho loads with twocolumn by default, where
-% the stock longtable environment cannot break across pages. The earlier
-% approach forced every longtable into a \begin{table}[H]+\tabular float,
-% which silently overflowed and, for tall tables (>1 page), sent xelatex
-% into an infinite output-routine loop ("Page number 65536 too large").
+% the stock longtable environment cannot break across pages. The original
+% approach forced every table into \begin{table}[H]+\tabular, which sent
+% xelatex into an infinite page loop for tall tables. A later attempt
+% wrapped the real longtable in \onecolumn/\twocolumn, which compiled
+% correctly but ejected a fresh column flush around every table and left
+% large blank regions between them.
 %
-% New approach: wrap the original longtable in a \onecolumn/\twocolumn
-% switch so page-breaking works. For single-column document classes this
-% is effectively a no-op. The switch forces a column flush which is the
-% standard cost of multi-page tables in twocolumn journal layouts.
+% Current approach: redirect longtable to a two-column-spanning float
+% (table*) with flexible placement [!tbp]. LaTeX's float mechanism then
+% places each table at the top, bottom, or on a dedicated float page,
+% whichever fits. Short tables flow in line with little extra space;
+% tables too tall for a column go to a float page. The tabular body does
+% not page-break, so genuinely multi-page tables must be split manually,
+% but this is rare in practice and preferable to the whitespace incurred
+% by a forced column flush around every table.
 \usepackage{array}
 \usepackage{longtable}
 \makeatletter
-\let\rho@origlongtable\longtable
-\let\rho@origendlongtable\endlongtable
-\newcommand{\rho@restorecolumn}{}
+\newcommand{\rho@colspec}{}
 \renewenvironment{longtable}[2][]{%
-  \if@twocolumn
-    \onecolumn
-    \def\rho@restorecolumn{\twocolumn}%
-  \else
-    \def\rho@restorecolumn{}%
-  \fi
-  \small
-  \rho@origlongtable[#1]{#2}%
+  \begin{table*}[!tbp]%
+  \centering\small
+  \gdef\rho@colspec{#2}%
+  \let\rho@origtabularnewline\tabularnewline
+  \def\tabularnewline{%
+    \let\tabularnewline\rho@origtabularnewline
+    \expandafter\tabular\expandafter{\rho@colspec}%
+  }%
 }{%
-  \rho@origendlongtable
-  \rho@restorecolumn
+  \bottomrule
+  \endtabular
+  \end{table*}%
 }
+\def\endfirsthead#1\endlastfoot{}
+\def\endhead{}
+\def\endfoot{}
+\def\endlastfoot{}
 \makeatother
 
 \usepackage{parskip}


### PR DESCRIPTION
Closes #74.

## Summary

- Redirect pandoc's `longtable` to `\begin{table*}[!tbp]` + `\tabular` instead of the v0.2.1 `\onecolumn` / `\twocolumn` wrap.
- LaTeX's float mechanism places tables wherever they fit (top, bottom, or a dedicated float page). Short tables flow inline; tall tables go to a float page. Neither case forces a column flush around the table.
- Same reference document (1000 lines markdown, 17 tables, rho twocolumn) drops from 40 pages (v0.2.1) to 18 pages (v0.2.2). Compile time and infinite-loop safety are unchanged.

## Trade-off

The `tabular` body does not page-break, so a single table taller than a full page must be split manually. In practice this is rare \\u2014 journal layouts rarely carry multi-page tables \\u2014 and it is preferable to the whitespace cost of unconditional column flushes.

## Test plan

- [x] `npm run verify` (typecheck, lint, template regressions, shortcut/command stability, installer syntax)
- [x] Full pandoc + xelatex compile of reference document: 18 pages, no infinite loop, no "Unable to place float" errors.
- [x] `templates/rho/rho.latex` retains `\usepackage{array}` before `\usepackage{longtable}` (enforced by `scripts/check-template-regressions.mjs`).

## Files touched

- `templates/rho/rho.latex`
- `CHANGELOG.md`
- `package.json` (version bump 0.2.1 \\u2192 0.2.2)