### PR TITLE
chore: package only pure template assets in VSIX (v0.2.3)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -28,4 +28,22 @@ out/shell-env.js
 out/templates.js
 out/toolchain.js
 .cursor/**
+# Keep the agent guide that ships with the extension (consumed by the
+# Setup Workspace command when .cursor/agents/ exists in the user's
+# project).
 !.cursor/agents/inkwell-guide.md
+# Exclude personal / scratch documents that must never ship to end
+# users. The published VSIX should contain templates + compiled
+# extension code only; anything else is either a local test artifact
+# or derivative content that was accidentally tracked in the past.
+demo.md
+demo.pdf
+# Example documents and their preview images. These are demo content,
+# not templates. Setup Workspace degrades gracefully when they are
+# absent (copyGuide / copyDemoFiles both short-circuit on ENOENT).
+guide.md
+examples/**
+media/examples/**
+# Generated artifacts under .inkwell/ (mermaid cache, compiled md,
+# outputs directory) are never part of a clean extension bundle.
+.inkwell/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.3 (2026-04-17)
+
+- **Package only pure template assets in the VSIX.** Earlier builds shipped `demo.md`, `examples/*.md`, `examples/*.pdf`, `guide.md`, `media/examples/*.png`, and generated `.inkwell/` artifacts (mermaid cache, compiled markdown). The published VSIX now contains `templates/`, the bundled extension code, the extension icon, and standard metadata (`LICENSE`, `README.md`, `CHANGELOG.md`, `package.json`) only. Setup Workspace continues to function \u2014 `copyGuide` and `copyDemoFiles` both fall back silently when the optional sources are absent.
+- **Purged prior VSIX releases.** The `v0.2.1` and `v0.2.2` GitHub release assets, which contained personal scratch content alongside the template fixes, have been removed. Install this release (`v0.2.3`) or `brew upgrade --cask inkwell` to get a clean bundle.
+
 ## 0.2.2 (2026-04-17)
 
 - **Rho template: reduce table whitespace.** The v0.2.1 fix eliminated the infinite-page loop on tall tables by wrapping every `longtable` in `\onecolumn` / `\twocolumn`, which forced a full column flush before and after each table. On documents with many tables this left large empty regions and inflated page count (40 pages for the 1000-line reference document, most of it blank). The revised approach redirects `longtable` to `\begin{table*}[!tbp]` + `\tabular`, a two-column-spanning float with flexible placement. LaTeX's float mechanism then places each table at the top, bottom, or on a dedicated float page, whichever fits. Same reference document now compiles to 18 pages with no infinite-loop risk.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
## Summary

- Exclude personal scratch content and generated artifacts from the published VSIX.
- Dropped: `demo.md`, `demo.pdf`, `examples/**`, `guide.md`, `media/examples/**`, `.inkwell/**` (mermaid cache, compiled markdown, outputs).
- Kept: `templates/**`, `out/extension.js`, `media/` (icon + marketplace screenshots + webview assets), `LICENSE`, `README.md`, `CHANGELOG.md`, `package.json`, `requirements-latex.txt` (tlmgr manifest used by `toolchain.ts`), `.cursor/agents/inkwell-guide.md` (explicit keep).
- VSIX drops from **121 files / 7.15 MB** to **74 files / 3.4 MB**.

## Test plan

- [x] `npm run verify` (typecheck, lint, template regressions, shortcut/command stability, installer syntax)
- [x] Local VSIX build: `npx vsce package` \\u2014 inspected archive, confirmed no personal content.
- [x] Scaffold degradation check: `copyGuide` and `copyDemoFiles` already short-circuit on missing sources (scaffold.ts:618\\u2013653); Setup Workspace will skip the guide/examples copy steps silently instead of crashing.

## Follow-up

After this merges and releases as v0.2.3, the leaked v0.2.1 and v0.2.2 GitHub release assets (which contained `demo.md` and `examples/demo-kth-letter.md`) will be deleted to purge the personal content from download.