### PR TITLE
fix(preview): block math centering + stronger code whitespace (v0.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.5 (2026-04-19)
+
+- **Preview: block math now renders as a proper centered display block.** The v0.2.4 math shield substituted `$$...$$` with a bare placeholder that markdown-it wrapped in a `<p>`. KaTeX's display-mode renderer emits a block-level `.katex-display` span, and nesting that inside a `<p>` forced the browser to auto-close the paragraph, which in turn broke the vertical rhythm and left the equation left-aligned where users expected it centered. Block math is now wrapped in `<div class="math-display">` (with surrounding blank lines so markdown-it treats it as an HTML block) and a matching CSS rule centers the output.
+- **Preview: force code-block whitespace preservation with `!important`.** The v0.2.4 `white-space: pre-wrap` rule was being overridden in practice \u2014 the host webview's default stylesheet (Cursor / VS Code) normalizes `<pre>` to `white-space: normal`, which collapsed newlines into spaces and produced the wrapped-paragraph effect that the earlier fix was meant to eliminate. Apply `white-space: pre-wrap`, `word-break: normal`, and `overflow-wrap: anywhere` with `!important` on `<pre>`, `<code>`, `pre code.hljs`, and nested highlight.js spans so the rule wins the cascade regardless of host defaults.
+
 ## 0.2.4 (2026-04-19)
 
 - **Preview: live bibliography and citations.** New `src/citations.ts` renders `[@key]` / `@key` citations in the preview with full pandoc parity when `pandoc` is on `PATH` (shells out to `pandoc --citeproc` against the frontmatter `bibliography`/`csl`), and falls back to a small in-process `.bib` parser otherwise. Results are cached under `.inkwell/.cache/preview-cites/` keyed on citation tokens, bib mtimes, CSL mtime, and the `link-citations` flag.

--- a/media/preview.css
+++ b/media/preview.css
@@ -97,25 +97,40 @@ pre {
     line-height: 1.45;
     margin: 1.2em 0;
     border: 1px solid var(--border);
-    /* Force whitespace preservation on code blocks. Without this, some
-       webview host stylesheets (VS Code's built-in content security
-       reset; highlight.js's markup choices) can degrade `<pre>` to
-       `white-space: normal`, collapsing newlines into spaces and
-       turning multi-line code into a single wrapped paragraph. Using
-       `pre-wrap` instead of `pre` lets long lines soft-wrap at the
-       preview column width instead of forcing a horizontal scrollbar. */
-    white-space: pre-wrap;
-    word-break: normal;
-    overflow-wrap: anywhere;
+    /* Force whitespace preservation on code blocks. Without !important
+       the host webview's default stylesheet (Cursor / VS Code injects a
+       reset that normalizes `<pre>` to `white-space: normal`) wins the
+       cascade and collapses every newline in the code block into a
+       single space. Use `pre-wrap` so long lines soft-wrap at the
+       preview column width instead of forcing a horizontal scrollbar,
+       and apply it with `!important` on both the `<pre>` wrapper and
+       any nested `<code>` / highlight.js span. */
+    white-space: pre-wrap !important;
+    word-break: normal !important;
+    overflow-wrap: anywhere !important;
     tab-size: 4;
 }
 
 pre code,
 pre code.hljs,
-pre > code {
-    white-space: inherit;
-    word-break: inherit;
-    overflow-wrap: inherit;
+pre > code,
+pre code span {
+    white-space: pre-wrap !important;
+    word-break: normal !important;
+    overflow-wrap: anywhere !important;
+}
+
+/* Block math wrapper from the markdown-it shield. KaTeX converts the
+   inner text to `<span class="katex-display">`; this outer div just
+   exists so markdown-it does not wrap the math in a `<p>`, which
+   would force the browser to auto-close the paragraph around the
+   block-level `katex-display` span and break its vertical rhythm. */
+.math-display {
+    margin: 1.2em 0;
+    overflow-x: auto;
+}
+.math-display .katex-display {
+    margin: 0;
 }
 
 pre code { background: none; padding: 0; font-size: 0.85em; border-radius: 0; }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -2110,7 +2110,16 @@ function shieldMathForMarkdown(body: string): {
     const idx = slots.length;
     slots.push(raw);
     const marker = `INKWELLMATHPLACEHOLDER${idx}ENDMATH`;
-    return inline ? `<span data-inkwell-math="${idx}">${marker}</span>` : marker;
+    if (inline) {
+      return `<span data-inkwell-math="${idx}">${marker}</span>`;
+    }
+    // Block math: wrap in a raw-HTML `<div>` with surrounding blank
+    // lines so markdown-it treats it as an HTML block and does not
+    // wrap it in `<p>`. KaTeX's display-mode renderer emits a
+    // block-level `<span class="katex-display">`; nesting that inside
+    // a `<p>` makes the browser auto-close the paragraph and breaks
+    // the centering / vertical spacing.
+    return `\n\n<div class="math-display" data-inkwell-math="${idx}">${marker}</div>\n\n`;
   };
 
   // Order matters: block forms first so inline `$` does not swallow


### PR DESCRIPTION
Follow-up to #77.

## Summary

- **Block math centering.** v0.2.4 substituted `$$...$$` with a bare placeholder that markdown-it wrapped in `<p>`. KaTeX's display-mode output is block-level, so nesting it in `<p>` caused the browser to auto-close the paragraph and broke the vertical rhythm. Block math now lives in `<div class=\"math-display\">` with blank lines around it so markdown-it treats it as an HTML block.
- **Code whitespace (again).** The v0.2.4 `white-space: pre-wrap` rule was being overridden by the host webview's default stylesheet. Applying the rule with `!important` on `<pre>`, `<code>`, and `pre code.hljs` lets the code block preserve newlines regardless of host cascade.

## Test plan

- [x] `npm run verify` \\u2014 clean.
- [x] Shield pipeline test: block `$$...$$` now emits `<div class=\"math-display\">...</div>` (no `<p>` wrap), inline `$...$` still emits `<span data-inkwell-math>`.