### PR TITLE
fix(preview): root-cause fix for <pre> corrupted to <p> (v0.2.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.6 (2026-04-19)
+
+- **Preview: root-cause fix for code blocks rendering without newlines.** `addDataLineAttrs` used the regex `/<(h[1-6]|p|pre|blockquote|table|ul|ol|li|hr)/g`. JavaScript regex alternation takes the *first* matching alternative, not the longest, so every `<pre>` tag was matched as `<p` (because `p` appears before `pre` in the list). The replacement then emitted `<p data-line="N"re>`, which the HTML parser silently collapses to a plain `<p>` tag with trailing garbage discarded \u2014 turning every fenced code block into a paragraph, losing `white-space: pre`, and collapsing all newlines into spaces. The earlier CSS rules (`white-space: pre-wrap`, `!important`, etc.) never took effect because the elements they targeted had already been corrupted from `<pre>` to `<p>` before reaching the DOM. Reorder alternations to put longer tokens first (`pre` before `p`) and add a `(?=[\s>])` lookahead so tag boundaries are respected.
+
 ## 0.2.5 (2026-04-19)
 
 - **Preview: block math now renders as a proper centered display block.** The v0.2.4 math shield substituted `$$...$$` with a bare placeholder that markdown-it wrapped in a `<p>`. KaTeX's display-mode renderer emits a block-level `.katex-display` span, and nesting that inside a `<p>` forced the browser to auto-close the paragraph, which in turn broke the vertical rhythm and left the equation left-aligned where users expected it centered. Block math is now wrapped in `<div class="math-display">` (with surrounding blank lines so markdown-it treats it as an HTML block) and a matching CSS rule centers the output.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1677,10 +1677,20 @@ function inkwellValue(block: string, key: string): string | undefined {
 
 function addDataLineAttrs(html: string): string {
   let lineCounter = 0;
-  return html.replace(/<(h[1-6]|p|pre|blockquote|table|ul|ol|li|hr)/g, (match, tag) => {
-    lineCounter++;
-    return `<${tag} data-line="${lineCounter}"`;
-  });
+  // Alternation order matters: JavaScript's regex engine takes the
+  // FIRST matching alternative, not the longest. If `p` appears before
+  // `pre`, the engine matches `<pre>` as `<p` and the replacement
+  // corrupts the opening tag to `<p data-line="N"re>`, which the HTML
+  // parser then collapses to a `<p>` \u2014 silently converting every code
+  // block into a paragraph, losing `white-space: pre`, and making all
+  // newlines disappear. Put longer tokens before their prefixes.
+  return html.replace(
+    /<(pre|h[1-6]|blockquote|table|ul|ol|li|hr|p)(?=[\s>])/g,
+    (_match, tag) => {
+      lineCounter++;
+      return `<${tag} data-line="${lineCounter}"`;
+    },
+  );
 }
 
 function escapeHtml(text: string): string {


### PR DESCRIPTION
Root cause for \"code blocks in Inkwell preview render without newlines\" (regular VS Code preview worked fine).

## The bug

\`addDataLineAttrs\` used \`/<(h[1-6]|p|pre|blockquote|table|ul|ol|li|hr)/g\`. JavaScript regex alternation takes the **first** matching alternative, not the longest. For input \`<pre>\`, the engine matched \`p\` and returned it as the captured group \u2014 the replacement then emitted \`<p data-line=\"N\"re>\`, which the HTML parser sees as a \`<p>\` tag with a stray token \`re\` (silently dropped). Every fenced code block was therefore being delivered to the DOM as a \`<p>\`, not a \`<pre>\`.

That killed the \`white-space: pre\` inheritance and collapsed every newline into a space, which is why the v0.2.4 and v0.2.5 CSS rules (\`pre-wrap\`, \`!important\`) had no visible effect \u2014 they were targeting the wrong element in the DOM.

## Fix

- Reorder the alternation so longer tokens come first (\`pre\` before \`p\`).
- Add a \`(?=[\\s>])\` lookahead so tag boundaries are respected.

## Test plan

- [x] Unit test against six representative HTML snippets including \`<pre><code>def f()...</pre>\` \u2014 \`<pre>\` is now preserved, paragraphs still get \`data-line\`, list items still get \`data-line\`, etc.
- [x] \`npm run verify\` clean.