### PR TITLE
feat(preview): mask LaTeX directives + default mermaid height cap (v0.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.7 (2026-04-19)
+
+- **Preview: mask LaTeX typesetting directives.** Stand-alone `\newpage`, `\clearpage`, `\cleardoublepage`, and `\pagebreak[N]` are replaced in the preview (and the print view) with a subtle dashed rule labelled "page break". Cosmetic spacing commands (`\vspace{..}`, `\hspace{..}`, `\vfill`, `\hfill`, `\bigskip`, `\medskip`, `\smallskip`, `\nopagebreak`, `\noindent`, `\par`, `\null`) are stripped silently. The source markdown is untouched, so the LaTeX compile pipeline still sees the directives verbatim. When the preview is printed through the browser, the page-break marker converts to an actual `page-break-after: always` so the break lands where the author asked for it.
+- **Preview: default mermaid height cap.** Uncontrolled diagrams were stretching the preview to multiple screens tall. Default `--mermaid-max-height: 70vh` applied to `.mermaid`, overridable via the existing frontmatter (`inkwell.mermaid-max-height`) or per-fence (`{mermaid max-height="400px"}`) mechanisms.
+
 ## 0.2.6 (2026-04-19)
 
 - **Preview: root-cause fix for code blocks rendering without newlines.** `addDataLineAttrs` used the regex `/<(h[1-6]|p|pre|blockquote|table|ul|ol|li|hr)/g`. JavaScript regex alternation takes the *first* matching alternative, not the longest, so every `<pre>` tag was matched as `<p` (because `p` appears before `pre` in the list). The replacement then emitted `<p data-line="N"re>`, which the HTML parser silently collapses to a plain `<p>` tag with trailing garbage discarded \u2014 turning every fenced code block into a paragraph, losing `white-space: pre`, and collapsing all newlines into spaces. The earlier CSS rules (`white-space: pre-wrap`, `!important`, etc.) never took effect because the elements they targeted had already been corrupted from `<pre>` to `<p>` before reaching the DOM. Reorder alternations to put longer tokens first (`pre` before `p`) and add a `(?=[\s>])` lookahead so tag boundaries are respected.

--- a/media/preview.css
+++ b/media/preview.css
@@ -398,6 +398,18 @@ em { font-style: italic; }
         line-height: var(--line-height, 1.4);
     }
 
+    /* Replace the decorative page-break marker with an actual page
+       break when the preview is printed through the browser. The
+       marker itself is not ink-worthy, but its position is: that is
+       where the author put `\newpage`. */
+    hr.page-break-marker {
+        border: none;
+        margin: 0;
+        page-break-after: always;
+        break-after: page;
+    }
+    hr.page-break-marker::after { content: none; }
+
     @page {
         size: var(--page-size, letter);
         margin: var(--page-margin-top, 1in) var(--page-margin-right, 1in)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -278,6 +278,14 @@ export class InkwellPreviewProvider {
       // Convert raw LaTeX table environments to HTML for preview
       body = convertLatexTables(body);
 
+      // LaTeX typesetting directives (\newpage, \vspace, \hfill, etc.)
+      // are meaningful for the PDF compile but render as literal text
+      // in the preview. Strip cosmetic spacing commands entirely; keep
+      // structural breaks (\newpage / \clearpage / \pagebreak) as a
+      // subtle marker so the reader can still see where the author
+      // intended a page boundary without the raw macro showing.
+      body = maskLatexTypesettingDirectives(body);
+
       // Shield math blocks from markdown-it's escape / emphasis rules
       // before rendering. markdown-it does not know about `$$...$$` or
       // `$...$` delimiters, so underscores, backslashes, and asterisks
@@ -525,7 +533,13 @@ export class InkwellPreviewProvider {
     .mermaid {
       text-align: center; margin: 1.5em auto;
       max-width: var(--mermaid-max-width, 100%);
-      max-height: var(--mermaid-max-height, none);
+      /* Default cap prevents a single uncontrolled diagram from
+         stretching the preview to multiple screens tall. Users can
+         relax the cap with the frontmatter setting
+         inkwell.mermaid-max-height (any CSS length like 90vh or
+         800px) or tighten it per-diagram with a max-height attribute
+         on the mermaid fence. */
+      max-height: var(--mermaid-max-height, 70vh);
       overflow: hidden;
     }
     .mermaid svg {
@@ -766,6 +780,36 @@ export class InkwellPreviewProvider {
     .page-sheet h1, .page-sheet h2, .page-sheet h3 {
       page-break-after: avoid; break-after: avoid;
     }
+
+    /* Visual marker that replaces the newpage / clearpage /
+       pagebreak LaTeX directives in the preview so the intent is
+       visible at a glance but not intrusive. The raw macro still
+       travels to the LaTeX compile pipeline untouched; this is a
+       preview-only affordance. Hidden inside print-view page-sheets
+       since those already paginate physically. */
+    hr.page-break-marker {
+      border: none;
+      border-top: 1px dashed var(--blockquote, #888);
+      margin: 2em 0;
+      position: relative;
+      overflow: visible;
+      opacity: 0.55;
+    }
+    hr.page-break-marker::after {
+      content: "page break";
+      position: absolute;
+      top: -0.7em;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0 0.6em;
+      background: var(--bg, #fff);
+      font-family: var(--body-font, serif);
+      font-size: 10px;
+      font-variant: small-caps;
+      letter-spacing: 0.12em;
+      color: var(--blockquote, #888);
+    }
+    .page-sheet hr.page-break-marker { display: none; }
 
     /* HLJS: match Pandoc Shaded background */
     .hljs { background: var(--code-bg); padding: 0; font-size: 0.85em; }
@@ -2092,6 +2136,47 @@ function tableFontSizeToCss(size: string): string | undefined {
 
 function applyBooktabsClasses(html: string): string {
   return html.replace(/<table>/g, '<table class="booktabs">');
+}
+
+/**
+ * Hide LaTeX typesetting-only directives from the preview while leaving
+ * the source markdown unchanged (the compile pipeline still sees them).
+ *
+ * - Structural page breaks (`\newpage`, `\clearpage`, `\pagebreak`) are
+ *   replaced with a raw HTML `<hr class="page-break-marker">` surrounded
+ *   by blank lines so markdown-it treats it as an HTML block. A CSS
+ *   rule styles the marker as a faint dashed rule with a "page break"
+ *   label, which is removed in the print view so the actual page-sheet
+ *   pagination does not collide with a decorative marker.
+ * - Cosmetic spacing commands (`\vspace{..}`, `\hspace{..}`, `\vfill`,
+ *   `\hfill`, `\bigskip`, `\medskip`, `\smallskip`, `\noindent`, `\par`)
+ *   are stripped entirely. They have no preview representation and
+ *   would otherwise surface as literal text.
+ */
+function maskLatexTypesettingDirectives(body: string): string {
+  let out = body;
+
+  // Page-break family -> visual marker.
+  out = out.replace(
+    /^[ \t]*\\(?:newpage|clearpage|cleardoublepage|pagebreak(?:\[\d+\])?)[ \t]*$/gm,
+    "\n\n<hr class=\"page-break-marker\">\n\n",
+  );
+
+  // Cosmetic spacing / layout directives -> drop.
+  const droppable: RegExp[] = [
+    /^[ \t]*\\nopagebreak(?:\[\d+\])?[ \t]*$/gm,
+    /^[ \t]*\\vfill[ \t]*$/gm,
+    /^[ \t]*\\hfill[ \t]*$/gm,
+    /^[ \t]*\\(?:big|med|small)skip[ \t]*$/gm,
+    /^[ \t]*\\vspace\*?\{[^}]*\}[ \t]*$/gm,
+    /^[ \t]*\\hspace\*?\{[^}]*\}[ \t]*$/gm,
+    /^[ \t]*\\noindent[ \t]*$/gm,
+    /^[ \t]*\\par[ \t]*$/gm,
+    /^[ \t]*\\null[ \t]*$/gm,
+  ];
+  for (const re of droppable) out = out.replace(re, "");
+
+  return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Mask LaTeX typesetting directives.** Stand-alone \`\\newpage\`, \`\\clearpage\`, \`\\cleardoublepage\`, and \`\\pagebreak[N]\` are replaced in the preview (and in the print view) with a dashed rule labelled \"page break\". Cosmetic spacing commands (\`\\vspace{..}\`, \`\\hspace{..}\`, \`\\vfill\`, \`\\hfill\`, \`\\bigskip\`, \`\\medskip\`, \`\\smallskip\`, \`\\nopagebreak\`, \`\\noindent\`, \`\\par\`, \`\\null\`) are stripped silently. The source markdown is untouched, so LaTeX compile still sees the directives verbatim. When the preview is browser-printed, the marker converts to an actual \`page-break-after: always\` via \`@media print\`.
- **Default mermaid height cap.** \`--mermaid-max-height: 70vh\` applied by default. Existing frontmatter (\`inkwell.mermaid-max-height\`) and per-fence (\`{mermaid max-height=\"400px\"}\`) overrides continue to work.

## Test plan

- [x] \`npm run verify\` clean.
- [x] Unit-tested mask regex against mixed block + inline directives; inline \`\\newpage\` mid-paragraph is left alone, stand-alone forms mask correctly.

## Notes

- Raw \`\\newpage\` mid-paragraph (uncommon) is NOT masked, because without seeing the surrounding context we cannot know the author's intent. The compile pipeline handles it regardless.
- The marker is a full-width dashed rule with the label \"page break\" in small-caps. It is hidden inside \`.page-sheet\` elements so the print view isn't doubly paginated.