### PR TITLE
fix(preview): honor refs placeholder + stub section + softer missing cites (v0.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.8 (2026-04-19)
+
+- **Preview: honor Pandoc `::: {#refs} :::` placeholder.** The rendered References section now lands at the author-controlled slot (Pandoc's `::: {#refs} :::` fenced div, as used by the rho / rmxaa / tufte templates) instead of being appended to the end of the document after every appendix. When no placeholder is present, we still append at the end.
+- **Preview: always render a References section when citations are present.** When every cited key is missing from the bibliography, pandoc emits no `<div id="refs">` block, so the earlier preview simply showed no References section at all \u2014 users ended up staring at broken-looking cites with no explanation. A stub References section is now synthesized listing each unresolved key under `<em>(not in bibliography)</em>` with a one-line note saying the bibliography resolved 0 of N cites. The stub makes the missing state obvious and tells the reader what entries to add.
+- **Preview: softer missing-citation rendering.** Pandoc emits missing cites as `(<strong>key?</strong>)` which reads like a compile error. Replace with a cleaner `<em>[key]</em>` in subtle gray (shares the `.citation-missing` class so the print view and the stub references section style consistently). The `data-cites` attribute and the link-to-refs anchor are preserved so cached keys and click-to-scroll still work.
+
 ## 0.2.7 (2026-04-19)
 
 - **Preview: mask LaTeX typesetting directives.** Stand-alone `\newpage`, `\clearpage`, `\cleardoublepage`, and `\pagebreak[N]` are replaced in the preview (and the print view) with a subtle dashed rule labelled "page break". Cosmetic spacing commands (`\vspace{..}`, `\hspace{..}`, `\vfill`, `\hfill`, `\bigskip`, `\medskip`, `\smallskip`, `\nopagebreak`, `\noindent`, `\par`, `\null`) are stripped silently. The source markdown is untouched, so the LaTeX compile pipeline still sees the directives verbatim. When the preview is printed through the browser, the page-break marker converts to an actual `page-break-after: always` so the break lands where the author asked for it.

--- a/media/preview.css
+++ b/media/preview.css
@@ -342,7 +342,25 @@ em { font-style: italic; }
 
 /* Citations (matches LaTeX hyperref citecolor) */
 .citation { color: var(--cite-color); text-decoration: none; }
-.citation-missing { color: #cc4444; font-style: italic; }
+.citation-missing { color: var(--blockquote, #888); font-style: italic; }
+.citation-missing-inline {
+    font-style: italic;
+    color: var(--blockquote, #888);
+    font-size: 0.92em;
+}
+
+/* Stub references block shown when the bibliography is configured but
+   every cited key is missing. Styled softer than a real References
+   section so the reader sees it as a pending state rather than an
+   authoritative bibliography. */
+.references-stub-note {
+    font-size: 0.9em;
+    color: var(--blockquote, #666);
+    margin: 0.4em 0 1em 0;
+}
+.references-stub .csl-entry.citation-missing {
+    opacity: 0.75;
+}
 
 .references,
 .references-section {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -263,6 +263,22 @@ export class InkwellPreviewProvider {
       body = citeResult.body;
       this.reportCitationStatus(citeResult);
 
+      // If the author marked a references slot with Pandoc's fenced-div
+      // `::: {#refs} ... :::` syntax (or similar variants such as
+      // `::: refs`), swap it out for a sentinel that we can replace with
+      // the CSL references block after markdown-it renders. markdown-it
+      // does not understand `:::` fenced divs, so without this step the
+      // `:::` lines surface as literal text in the preview.
+      const refsPlaceholder = INKWELL_REFS_SLOT;
+      let refsSlotInjected = false;
+      body = body.replace(
+        /^:::\s*(?:\{#refs[^}]*\}|refs)\s*$[\s\S]*?^:::\s*$/gm,
+        () => {
+          refsSlotInjected = true;
+          return `\n\n${refsPlaceholder}\n\n`;
+        },
+      );
+
       // Strip any remaining Pandoc header attributes not caught above
       body = body.replace(/\s*\{[#.][\w:. -]+\}\s*$/gm, "");
       // Clean up unresolved inline expression errors for preview
@@ -299,6 +315,7 @@ export class InkwellPreviewProvider {
       rendered = restore(rendered);
       rendered = this.convertLocalImages(rendered, document);
       rendered = applyBooktabsClasses(rendered);
+      rendered = softenMissingCitations(rendered);
       htmlBody = addDataLineAttrs(rendered);
       title = fm.title;
 
@@ -333,8 +350,22 @@ export class InkwellPreviewProvider {
         }
       }
 
-      if (citeResult.referencesHtml) {
-        htmlBody = htmlBody + citeResult.referencesHtml;
+      // Build the final references section. Prefer pandoc's rendered
+      // CSL block; when every key is missing (pandoc emits no refs div
+      // in that case), synthesize a stub that lists the unresolved
+      // keys so the reader still sees a visible References section and
+      // knows which entries the bibliography is missing.
+      const referencesHtml = buildReferencesSection(citeResult);
+      if (referencesHtml) {
+        if (refsSlotInjected && htmlBody.includes(refsPlaceholder)) {
+          htmlBody = htmlBody.replace(refsPlaceholder, referencesHtml);
+        } else {
+          htmlBody = htmlBody + referencesHtml;
+        }
+      } else if (refsSlotInjected) {
+        // Author asked for refs but there were no citations at all;
+        // drop the placeholder so it doesn't appear as raw text.
+        htmlBody = htmlBody.replace(refsPlaceholder, "");
       }
     }
 
@@ -2136,6 +2167,78 @@ function tableFontSizeToCss(size: string): string | undefined {
 
 function applyBooktabsClasses(html: string): string {
   return html.replace(/<table>/g, '<table class="booktabs">');
+}
+
+const INKWELL_REFS_SLOT = "<!--INKWELL-REFS-SLOT-->";
+
+/**
+ * Assemble the final References section HTML.
+ *
+ * Pandoc normally emits a `<div id="refs">` block that we pick up via
+ * `citeResult.referencesHtml`. But when EVERY cited key is missing from
+ * the configured bibliography, pandoc emits no references block at
+ * all, which leaves the author staring at a document whose cites look
+ * broken and with no explanation why. Synthesize a fallback section
+ * that lists each unresolved key under the "References" heading with
+ * an italic "(not in bibliography)" marker, so the user sees where a
+ * real entry is expected and what key is missing.
+ *
+ * When there are no citations in the document at all, return `""`:
+ * the author did not ask for a References section and we should not
+ * conjure one.
+ */
+function buildReferencesSection(
+  r: Pick<CitationRenderResult, "referencesHtml" | "resolvedKeys" | "missingKeys">,
+): string {
+  if (r.referencesHtml && r.referencesHtml.trim()) {
+    return r.referencesHtml;
+  }
+  if (r.missingKeys.size === 0 && r.resolvedKeys.size === 0) {
+    return "";
+  }
+  const items = [...r.missingKeys].sort().map((key) => {
+    const safeKey = escapeHtml(key);
+    return `<div class="csl-entry citation-missing" id="ref-${safeKey}"><strong>${safeKey}</strong> <em>(not in bibliography)</em></div>`;
+  }).join("\n");
+  return [
+    '<section class="references-section references-stub">',
+    '<h2 class="references-heading">References</h2>',
+    '<p class="references-stub-note"><em>Bibliography resolved 0 of ',
+    String(r.missingKeys.size + r.resolvedKeys.size),
+    ' citations. Add the following entries to your <code>.bib</code> file:</em></p>',
+    '<div class="csl-bib-body">',
+    items,
+    '</div>',
+    '</section>',
+  ].join("");
+}
+
+/**
+ * Pandoc-citeproc renders missing citations as `(<strong>key?</strong>)`
+ * inside a `<span class="citation-missing">` (or, for bracketed groups,
+ * without that class). That bold-with-question-mark styling reads as an
+ * error; a softer `[key]` in italic gray with the `.citation-missing`
+ * class applied uniformly is easier to scan and makes it obvious the
+ * reference is pending rather than broken.
+ */
+function softenMissingCitations(html: string): string {
+  // Replace `<strong>key?</strong>` inside any .citation span with a
+  // cleaner `[key]` marker. The outer span keeps its data-cites attr
+  // so click-to-scroll and cache keying still work.
+  return html.replace(
+    /(<span[^>]*class="[^"]*citation[^"]*"[^>]*>)([\s\S]*?)(<\/span>)/g,
+    (_m, open: string, inner: string, close: string) => {
+      const replaced = inner.replace(
+        /<strong>([^<]+?)\?<\/strong>/g,
+        (_, key: string) => `<em class="citation-missing-inline">[${escapeHtml(key)}]</em>`,
+      );
+      const wasMissing = replaced !== inner;
+      const openAdj = wasMissing && !/citation-missing/.test(open)
+        ? open.replace(/class="([^"]*)"/, 'class="$1 citation-missing"')
+        : open;
+      return openAdj + replaced + close;
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

References and citations in the preview now behave as users expect regardless of the state of the configured bibliography.

- **Honor Pandoc's `::: {#refs} :::` placeholder.** The rendered References section now lands where the author placed the fenced-div marker (matches the rho, rmxaa, and tufte templates' conventions) instead of being appended after every appendix. Falls back to end-of-document append when no placeholder is present.
- **Stub References section when all keys are missing.** Pandoc emits no \`<div id=\"refs\">\` when every cited key is unresolved, which left the preview with no visible bibliography at all and no indication why. A stub section is now synthesized that lists each unresolved key with a \"not in bibliography\" marker and a one-line note showing the resolved / total count.
- **Softer missing-citation rendering.** Pandoc's default \`(<strong>key?</strong>)\` reads like a compile error. Replace with a cleaner \`<em>[key]</em>\` in the subtle \`.citation-missing\` color, keeping \`data-cites\` and the anchor href for click-to-scroll.

## Test plan

- [x] \`npm run verify\`
- [x] Unit-tested the two main transforms:
  - \`::: {#refs} :::\` -> sentinel -> References block injected in place
  - Pandoc output with \`(<strong>key?</strong>)\` -> \`<em class=\"citation-missing-inline\">[key]</em>\` with \`.citation-missing\` class applied to the outer span
- [ ] Reviewer: reload the preview on a document whose \`bibliography\` is set but whose cited keys are missing; verify (a) the stub References section appears under \`::: {#refs} :::\` (or at the end), (b) inline missing cites render as soft italic \`[key]\` instead of bold \`(key?)\`, (c) when the bibliography is populated, the normal CSL-styled entries appear in the same slot.