### PR TITLE
feat(preview): print-as-pdf + heading/code/caption typography + numbering styles (v0.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.9 (2026-04-19)
+
+- **Print button now renders a PDF.** `window.print()` inside a VS Code webview is unreliable (the sandbox often swallows the dialog silently), so the Print toolbar button now triggers the same Pandoc + XeLaTeX compile pipeline as the Compile button. The PDF shows in the PDF tab when it is ready.
+- **Heading typography controls.** `inkwell.heading-font`, `inkwell.heading-color`, `inkwell.heading-weight`, and `inkwell.heading-scale` apply to `h1` through `h6`. Defaults remain unchanged; `heading-scale` is a single multiplier so you can push every heading up or down together. Already-supported `mainfont` / `monofont` continue to control body and mono type.
+- **Code and caption font sizes.** `inkwell.code-font-size` (applies to `<pre><code>`) and `inkwell.caption-font-size` (applies to `figcaption` and `.table-caption`). Accepts any CSS length or the named sizes the existing `table-font-size` accepts.
+- **Section numbering styles.** `inkwell.section-numbering: decimal | legal | none`.
+  - `decimal` (default): `1`, `1.1`, `1.1.1`
+  - `legal` / `outline`: `1`, `1.b`, `1.b.iii`, `1.b.iii.(2)`, `1.b.iii.(2).(e)`
+  - `none`: no auto-numbering; the heading text renders on its own. Figure and table prefixes still number normally.
+
 ## 0.2.8 (2026-04-19)
 
 - **Preview: honor Pandoc `::: {#refs} :::` placeholder.** The rendered References section now lands at the author-controlled slot (Pandoc's `::: {#refs} :::` fenced div, as used by the rho / rmxaa / tufte templates) instead of being appended to the end of the document after every appendix. When no placeholder is present, we still append at the end.

--- a/media/preview.css
+++ b/media/preview.css
@@ -25,6 +25,14 @@
     /* Mermaid sizing defaults; overridden by frontmatter or per-block attrs. */
     --mermaid-max-width: 100%;
     --mermaid-max-height: none;
+    /* Heading, code, caption typography defaults. Frontmatter
+       inkwell.heading-font / heading-color / heading-weight / heading-scale
+       / code-font-size / caption-font-size override these. */
+    --heading-color: inherit;
+    --heading-weight: 700;
+    --heading-scale: 1;
+    --code-font-size: 0.85em;
+    --caption-font-size: 0.95em;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -64,17 +72,20 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
     font-family: var(--heading-font);
-    font-weight: 700;
+    font-weight: var(--heading-weight);
+    color: var(--heading-color);
     margin-top: 1.8em;
     margin-bottom: 0.6em;
     line-height: 1.25;
     scroll-margin-top: 16px;
 }
 
-h1 { font-size: 1.6em; }
-h2 { font-size: 1.3em; }
-h3 { font-size: 1.1em; }
-h4 { font-size: 1em; font-style: italic; font-weight: 600; }
+h1 { font-size: calc(1.6em * var(--heading-scale)); }
+h2 { font-size: calc(1.3em * var(--heading-scale)); }
+h3 { font-size: calc(1.1em * var(--heading-scale)); }
+h4 { font-size: calc(1em * var(--heading-scale)); font-style: italic; font-weight: 600; }
+h5 { font-size: calc(0.95em * var(--heading-scale)); font-weight: 600; }
+h6 { font-size: calc(0.9em * var(--heading-scale)); font-weight: 600; color: var(--blockquote); }
 
 p { margin: var(--paragraph-spacing) 0; }
 
@@ -118,6 +129,7 @@ pre code span {
     white-space: pre-wrap !important;
     word-break: normal !important;
     overflow-wrap: anywhere !important;
+    font-size: var(--code-font-size);
 }
 
 /* Block math wrapper from the markdown-it shield. KaTeX converts the
@@ -200,7 +212,7 @@ body.table-style-plain tbody tr:last-child {
 
 /* Table captions. Default is below-table; caption-above flips it. */
 .table-caption {
-    font-size: 0.9em;
+    font-size: var(--caption-font-size);
     color: var(--blockquote);
     margin-top: 0.4em;
     margin-bottom: 1.5em;
@@ -245,7 +257,7 @@ img {
 }
 figure { margin: 1.5em 0; text-align: center; }
 figcaption {
-    font-size: 0.9em;
+    font-size: var(--caption-font-size);
     color: var(--blockquote);
     margin-top: 0.5em;
     font-style: italic;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -249,7 +249,12 @@ export class InkwellPreviewProvider {
         eqn: fm.eqnPrefix || "Equation",
         sec: fm.secPrefix || "Section",
       };
-      let body = resolveReferences(fm.body, mermaidMeta, prefixes);
+      let body = resolveReferences(
+        fm.body,
+        mermaidMeta,
+        prefixes,
+        fm.sectionNumbering || "decimal",
+      );
 
       const projectRoot = getInkwellProjectRoot(sourceFile);
       const citeResult = await renderCitations(body, {
@@ -1434,16 +1439,13 @@ export class InkwellPreviewProvider {
     }
 
     printBtn.addEventListener("click", function() {
-      document.body.classList.add("printing");
-      var wasTab = currentTab;
-      if (wasTab !== "preview") {
-        switchTab("preview");
-      }
-      setTimeout(function() {
-        try { window.print(); } catch (e) {}
-        document.body.classList.remove("printing");
-        if (wasTab !== currentTab) switchTab(wasTab);
-      }, 120);
+      // window.print() is unreliable inside a VS Code webview (the
+      // sandbox often swallows the dialog silently), so rebind Print
+      // to the same pipeline as the Compile button: pandoc + xelatex
+      // produces a real PDF and the extension then switches to the
+      // PDF tab to display it. This matches what "print" means for a
+      // typeset document anyway.
+      vscodeApi.postMessage({ type: "compile" });
     });
 
     window.addEventListener("message", function(event) {
@@ -1631,11 +1633,28 @@ interface FrontmatterResult {
   // specify their own {mermaid max-width="..."} attributes)
   mermaidMaxWidth?: string;
   mermaidMaxHeight?: string;
+  // Heading and code typography
+  headingFont?: string;
+  headingColor?: string;
+  headingWeight?: string;
+  headingScale?: number;
+  codeFontSize?: string;
+  captionFontSize?: string;
+  sectionNumbering?: SectionNumberingStyle;
   // Citations
   bibliography?: string[];
   csl?: string;
   linkCitations?: boolean;
 }
+
+/**
+ * Section-numbering style for auto-generated heading numbers.
+ *
+ * - `decimal`: 1 / 1.1 / 1.1.1 (default; matches Pandoc / LaTeX default)
+ * - `legal`:   1 / 1.a / 1.a.i / 1.a.i.(1) (outline / legal style)
+ * - `none`:    no numbers
+ */
+type SectionNumberingStyle = "decimal" | "legal" | "none";
 
 function stripFrontmatter(text: string): FrontmatterResult {
   const match = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
@@ -1694,6 +1713,34 @@ function stripFrontmatter(text: string): FrontmatterResult {
   const mermaidMaxHeight = inkwellBlock
     ? inkwellValue(inkwellBlock, "mermaid-max-height")
     : undefined;
+  const headingFont = inkwellBlock
+    ? inkwellValue(inkwellBlock, "heading-font")
+    : undefined;
+  const headingColor = inkwellBlock
+    ? inkwellValue(inkwellBlock, "heading-color")
+    : undefined;
+  const headingWeight = inkwellBlock
+    ? inkwellValue(inkwellBlock, "heading-weight")
+    : undefined;
+  const headingScaleRaw = inkwellBlock
+    ? inkwellValue(inkwellBlock, "heading-scale")
+    : undefined;
+  const headingScale = headingScaleRaw ? parseFloat(headingScaleRaw) : undefined;
+  const codeFontSize = inkwellBlock
+    ? inkwellValue(inkwellBlock, "code-font-size")
+    : undefined;
+  const captionFontSize = inkwellBlock
+    ? inkwellValue(inkwellBlock, "caption-font-size")
+    : undefined;
+  const sectionNumberingRaw = inkwellBlock
+    ? inkwellValue(inkwellBlock, "section-numbering")
+    : undefined;
+  const sectionNumbering: SectionNumberingStyle =
+    sectionNumberingRaw === "legal" || sectionNumberingRaw === "outline"
+      ? "legal"
+      : sectionNumberingRaw === "none" || sectionNumberingRaw === "off"
+      ? "none"
+      : "decimal";
 
   const linkCitRaw = scalar("link-citations");
   const linkCitations =
@@ -1724,6 +1771,13 @@ function stripFrontmatter(text: string): FrontmatterResult {
     captionStyle,
     mermaidMaxWidth,
     mermaidMaxHeight,
+    headingFont,
+    headingColor,
+    headingWeight,
+    headingScale: Number.isFinite(headingScale) && headingScale! > 0 ? headingScale : undefined,
+    codeFontSize,
+    captionFontSize,
+    sectionNumbering,
     bibliography: list("bibliography"),
     csl: scalar("csl"),
     linkCitations,
@@ -1848,10 +1902,72 @@ function sanitizeCssLength(raw: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Format a section counter array into a label string per the chosen
+ * numbering style.
+ *
+ *   decimal (default): [1, 2, 3]     -> "1.2.3"
+ *   legal / outline:   [1, 2, 3]     -> "1.b.iii"
+ *                      [1, 2, 3, 4]  -> "1.b.iii.(4)"
+ *                      [1, 2, 3, 4, 5] -> "1.b.iii.(4).(e)"
+ *   none:              [1, 2, 3]     -> ""
+ *
+ * The legal style uses: uppercase decimal for level 1, lowercase latin
+ * for level 2, lowercase roman for level 3, parenthesised decimal for
+ * level 4, parenthesised latin for level 5+ (uncommon but preserves
+ * distinctness).
+ */
+function formatSectionNumber(counters: number[], style: SectionNumberingStyle): string {
+  const active = counters.filter((n) => n > 0);
+  if (!active.length) return "";
+  if (style === "none") return "";
+  if (style === "decimal") return active.join(".");
+  // legal / outline
+  const parts: string[] = [];
+  for (let i = 0; i < active.length; i++) {
+    const n = active[i];
+    if (i === 0) parts.push(String(n));
+    else if (i === 1) parts.push(latinLower(n));
+    else if (i === 2) parts.push(romanLower(n));
+    else if (i === 3) parts.push(`(${n})`);
+    else parts.push(`(${latinLower(n)})`);
+  }
+  return parts.join(".");
+}
+
+function latinLower(n: number): string {
+  // 1 -> a, 2 -> b, ..., 26 -> z, 27 -> aa, 28 -> ab, ...
+  if (n <= 0) return "";
+  let s = "";
+  let v = n;
+  while (v > 0) {
+    const rem = (v - 1) % 26;
+    s = String.fromCharCode(97 + rem) + s;
+    v = Math.floor((v - 1) / 26);
+  }
+  return s;
+}
+
+function romanLower(n: number): string {
+  if (n <= 0 || n >= 4000) return String(n);
+  const table: Array<[number, string]> = [
+    [1000, "m"], [900, "cm"], [500, "d"], [400, "cd"],
+    [100, "c"], [90, "xc"], [50, "l"], [40, "xl"],
+    [10, "x"], [9, "ix"], [5, "v"], [4, "iv"], [1, "i"],
+  ];
+  let v = n;
+  let out = "";
+  for (const [val, sym] of table) {
+    while (v >= val) { out += sym; v -= val; }
+  }
+  return out;
+}
+
 function resolveReferences(
   body: string,
   mermaidMeta: MermaidMeta[],
   prefixes: { fig: string; tbl: string; eqn: string; sec: string },
+  sectionNumbering: SectionNumberingStyle = "decimal",
 ): string {
   const labels = new Map<string, string>();
   const secNums = [0, 0, 0, 0, 0, 0];
@@ -1867,11 +1983,9 @@ function resolveReferences(
         const level = hashes.length - 1;
         secNums[level]++;
         for (let i = level + 1; i < secNums.length; i++) secNums[i] = 0;
-        const num = secNums
-          .slice(0, level + 1)
-          .filter((n) => n > 0)
-          .join(".");
-        labels.set(label, `${prefixes.sec}\u00a0${num}`);
+        const num = formatSectionNumber(secNums.slice(0, level + 1), sectionNumbering);
+        if (num) labels.set(label, `${prefixes.sec}\u00a0${num}`);
+        else labels.set(label, prefixes.sec);
       }
       return `${hashes} <a id="${label}"></a>${title}`;
     },
@@ -2064,6 +2178,33 @@ function buildLayoutStyle(fm: FrontmatterResult): LayoutPayload {
   const mmh = fm.mermaidMaxHeight ? sanitizeCssLength(fm.mermaidMaxHeight) : undefined;
   if (mmh) vars.push(`--mermaid-max-height: ${mmh}`);
 
+  // Heading typography (separate from body font so the author can
+  // pair, say, a serif body with a sans display face for headings).
+  if (fm.headingFont) {
+    const safe = fm.headingFont.replace(/'/g, "\\'");
+    // Overrides the --heading-font set by mainfont above.
+    vars.push(`--heading-font: '${safe}', Georgia, 'Palatino Linotype', serif`);
+  }
+  if (fm.headingColor && /^[#a-zA-Z0-9(),.\s%-]+$/.test(fm.headingColor)) {
+    vars.push(`--heading-color: ${fm.headingColor}`);
+  }
+  if (fm.headingWeight && /^(\d{3}|normal|bold|lighter|bolder)$/.test(fm.headingWeight)) {
+    vars.push(`--heading-weight: ${fm.headingWeight}`);
+  }
+  if (fm.headingScale && fm.headingScale > 0 && fm.headingScale < 4) {
+    vars.push(`--heading-scale: ${fm.headingScale}`);
+  }
+
+  // Code and caption font-size controls.
+  if (fm.codeFontSize) {
+    const cfs = tableFontSizeToCss(fm.codeFontSize);
+    if (cfs) vars.push(`--code-font-size: ${cfs}`);
+  }
+  if (fm.captionFontSize) {
+    const capfs = tableFontSizeToCss(fm.captionFontSize);
+    if (capfs) vars.push(`--caption-font-size: ${capfs}`);
+  }
+
   const tableStyle = fm.tableStyle || "booktabs";
   vars.push(`--table-style: "${tableStyle}"`);
   if (fm.tableStripe) {
@@ -2078,6 +2219,7 @@ function buildLayoutStyle(fm: FrontmatterResult): LayoutPayload {
   if (fm.captionStyle === "above") bodyClasses.push("caption-above");
   else bodyClasses.push("caption-below");
   if (fm.pagestyle) bodyClasses.push(`pagestyle-${fm.pagestyle.replace(/[^\w-]/g, "")}`);
+  bodyClasses.push(`section-numbering-${fm.sectionNumbering || "decimal"}`);
 
   const cssText = vars.length ? `:root { ${vars.join("; ")}; }` : "";
   return { cssText, bodyClasses };


### PR DESCRIPTION
## Summary

- **Print button renders a PDF.** \`window.print()\` inside a VS Code webview is unreliable; rebind Print to the existing Compile pipeline so it produces a real PDF in the PDF tab.
- **Heading typography.** \`inkwell.heading-font | heading-color | heading-weight | heading-scale\` apply to \`h1\`\u2013\`h6\`. Defaults unchanged.
- **Code + caption font sizes.** \`inkwell.code-font-size\` and \`inkwell.caption-font-size\`.
- **Section-numbering styles.** \`inkwell.section-numbering: decimal | legal | none\`.

## Test plan

- [x] \`npm run verify\`
- [x] Unit test numbering formatter: decimal / legal / none across depths 1\u20134
- [ ] Reviewer: reload preview on a document with \`inkwell.section-numbering: legal\` and verify headings read \`1\`, \`1.b\`, \`1.b.iii\`, etc.
- [ ] Reviewer: click Print \u2192 PDF appears in the PDF tab.