### PR TITLE
fix(preview): regex transforms must not eat blank lines after {#label} (v0.2.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.10 (2026-04-19)
+
+- **Preview: stop regex transforms from eating the blank line after a `{#label}` attribute.** The body pre-processors used `\s*$` with the `/m` flag when stripping Pandoc attribute blocks (heading `{#sec:...}`, table caption `{#tbl:...}`, `:::` fenced-div refs slot, and the catch-all trailing-attrs sweep). JavaScript's `\s` matches `\n`, so a greedy `\s*$` consumed the blank line *after* the attribute and glued the next markdown block onto the previous one. Downstream, markdown-it saw a `<figcaption>...</figcaption>` on one line immediately followed by `## Heading` and `1. List item`, which triggers CommonMark's HTML-block rule: the heading and the list got swallowed into the HTML block and were rendered as literal text instead of as a heading and an ordered list. Replace `\s*$` with `[ \t]*$` (and similarly for the leading side where present) so only horizontal whitespace is consumed, preserving the blank line that markdown-it needs as a block separator.
+
 ## 0.2.9 (2026-04-19)
 
 - **Print button now renders a PDF.** `window.print()` inside a VS Code webview is unreliable (the sandbox often swallows the dialog silently), so the Print toolbar button now triggers the same Pandoc + XeLaTeX compile pipeline as the Compile button. The PDF shows in the PDF tab when it is ready.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -277,15 +277,20 @@ export class InkwellPreviewProvider {
       const refsPlaceholder = INKWELL_REFS_SLOT;
       let refsSlotInjected = false;
       body = body.replace(
-        /^:::\s*(?:\{#refs[^}]*\}|refs)\s*$[\s\S]*?^:::\s*$/gm,
+        /^:::[ \t]*(?:\{#refs[^}]*\}|refs)[ \t]*$[\s\S]*?^:::[ \t]*$/gm,
         () => {
           refsSlotInjected = true;
           return `\n\n${refsPlaceholder}\n\n`;
         },
       );
 
-      // Strip any remaining Pandoc header attributes not caught above
-      body = body.replace(/\s*\{[#.][\w:. -]+\}\s*$/gm, "");
+      // Strip any remaining Pandoc header attributes not caught above.
+      // Use [ \t]*$ rather than \s*$ — JavaScript's `\s` matches `\n`,
+      // and with the /m flag the greedy `\s*$` will eat the blank line
+      // *after* the attribute, merging the attribute's line into the
+      // next block. That broke lists and headings downstream of any
+      // `{#foo}` attribute.
+      body = body.replace(/[ \t]*\{[#.][\w:. -]+\}[ \t]*$/gm, "");
       // Clean up unresolved inline expression errors for preview
       body = body.replace(
         /\?\?\(([^)]+)\)/g,
@@ -1975,9 +1980,14 @@ function resolveReferences(
   let tblNum = 0;
   let eqNum = 0;
 
-  // Headers: # Title {#sec:label} -> numbered anchor + clean heading
+  // Headers: # Title {#sec:label} -> numbered anchor + clean heading.
+  // NB: use [ \t]* for the surrounding whitespace rather than \s* —
+  // \s matches \n and, with /m, a greedy \s*$ eats the blank line
+  // after the heading and glues the heading into whatever block
+  // follows (list, paragraph, table). That causes markdown-it to
+  // render both as a single run of text.
   let result = body.replace(
-    /^(#{1,6})\s+(.*?)\s*\{#([\w:.-]+)\}\s*$/gm,
+    /^(#{1,6})\s+(.*?)[ \t]*\{#([\w:.-]+)\}[ \t]*$/gm,
     (_, hashes: string, title: string, label: string) => {
       if (label.startsWith("sec:")) {
         const level = hashes.length - 1;
@@ -2035,7 +2045,7 @@ function resolveReferences(
 
   // Table caption labels: : caption {#tbl:label} -> HTML figcaption
   result = result.replace(
-    /^:\s+(.*?)\s*\{#(tbl:[\w:.-]+)\}\s*$/gm,
+    /^:\s+(.*?)[ \t]*\{#(tbl:[\w:.-]+)\}[ \t]*$/gm,
     (_, caption: string, label: string) => {
       tblNum++;
       labels.set(label, `${prefixes.tbl}\u00a0${tblNum}`);


### PR DESCRIPTION
## Root cause

Four body-preprocessing regexes used \`\\s*\$\` with the \`/m\` flag when stripping Pandoc attribute blocks. JavaScript's \`\\s\` matches \`\\n\`, so the greedy \`\\s*\$\` consumed the **blank line after** the attribute, not just the inline whitespace before the line break. markdown-it then received the replaced HTML (like \`<figcaption>...</figcaption>\`) immediately followed by \`## Heading\` with no blank separator. CommonMark's HTML-block rule treats that as a continuation of the HTML block, which swallows the heading and any following list, paragraph, or table \u2014 rendering them as literal text.

## Fix

Replace \`\\s*\$\` with \`[ \\t]*\$\` (horizontal whitespace only) on every affected regex. The blank line survives as a block separator.

Affected regexes:
- heading with attr (\`## Title {#sec:label}\`)
- pandoc table caption (\`: caption {#tbl:label}\`)
- refs slot (\`::: {#refs} :::\`)
- catch-all trailing-attrs sweep (\`\\s*\\{[#.][\\w:. -]+\\}\\s*\$\`)

## Test plan

- [x] \`npm run verify\`
- [x] Replayed the real problematic slice from \`demo.md\` (table caption at \`: Key notebook widget parameters. {#tbl:widgets}\` immediately followed by \`## Cell execution order {#sec:cells}\` and a numbered list). Before the fix, the heading and list rendered as one run of literal text. After the fix, proper \`<h2>\` + \`<ol><li>\` + inline emphasis.