### PR TITLE
feat: toolchain reliability + two-pass engine + template babel fix (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.3.0 (2026-04-19)
+
+Reliability release. Addresses five classes of failure observed during automated PDF rebuilds on a clean TinyTeX install. Every one of these produced a failing compile or a silently corrupted PDF on machines without a full MacTeX.
+
+### Fixed
+
+- **rho and rmxaa templates: unconditional `\\iflanguage{spanish}` crashes on babel-english-only installs.** The rho class's `rhobabel.sty` and the rmxaa class's `rhobabel.sty` both contain ~20 `\\iflanguage{spanish}{...}{...}` branches. `\\iflanguage` is a hard error (not a silent `false`) when the language has not been declared to `babel`. The previous template wrappers loaded `\\usepackage[english]{babel}`, so the condition was always undefined unless the user's format file happened to have Spanish preloaded \u2014 which TinyTeX and BasicTeX do not. Load `[spanish,english]{babel}` in both template wrappers so the condition resolves, with `english` remaining the primary language. Add `babel-spanish` and `hyphen-spanish` to the shipped requirements list so the language is actually available when tlmgr is used for the initial package pass.
+- **Compile: two-pass engine resolution for cross-references.** The single-pass `pandoc --pdf-engine=...` flow ran the engine only once, which left `\\ref{...}`, `\\pageref{LastPage}`, `\\tableofcontents`, and pandoc-crossref's internal refs unresolved. Every rho / rmxaa PDF showed `Page 1 of ??` on a cold cache, and any \u2198`@fig:` / `@tbl:` / `@eq:` / `@sec:` reference fell through to a literal `??`. The pipeline now emits the template-processed `.tex` first, then runs the engine twice; raw-LaTeX `\\cite{...}` paths also get a biber / bibtex pass when the generated `.tex` contains a `\\bibliography{...}` or `\\addbibresource{...}` line.
+- **Missing TinyTeX packages.** Clean TinyTeX installs of the default / rho / rmxaa templates hit `File 'xstring.sty' not found` or `fixtounicode.sty` on first compile. Add `xstring`, `fix2col`, `babel-spanish`, `hyphen-spanish` to `requirements-latex.txt` and to the `toolchain.ts` fallback list. Map `babel-spanish`, `hyphen-spanish`, `fix2col` in the `kpsewhich` probe so the toolchain check correctly reports their install state instead of always reporting them missing.
+
+### Added
+
+- **Toolchain: TEXMFROOT ownership + writeability check.** `kpsewhich -var-value TEXMFROOT` is probed, and when it resolves to a directory owned by a user other than the current one AND not writable by the current user, the toolchain report surfaces the ownership mismatch and offers a one-click `sudo chown -R "$USER" "$TEXMFROOT"` remediation. This is the single hardest-to-diagnose failure mode for TinyTeX bootstrapped via `curl ... | sudo sh`: `tlmgr install` succeeds silently but `kpsewhich` never sees the new files because the `ls-R` index cannot be updated as a non-root user.
+- **Install script: ownership warning.** `scripts/install-inkwell-macos.sh` now runs the same `kpsewhich` ownership check post-install and prints an actionable warning with the exact `chown` command when the TeX tree is root-owned.
+- **Compile log: full pandoc argv.** The extension's Inkwell output channel now logs the exact `pandoc` argv (including `TEXINPUTS`, `--resource-path`, and every engine-pass command) in a form that can be pasted into a terminal to reproduce a failure outside the extension. Previously this required reading the minified bundle.
+- **`guide.md`: Troubleshooting section.** Documents the symptoms and remediations for the failure modes above, plus the preview-webview-not-refreshing case and how to find the compile invocation in the output channel.
+
+### Template coverage audit
+
+- **rho**: babel fix applied (`[spanish,english]{babel}`).
+- **rmxaa**: babel fix applied (wrapper previously loaded no babel at all).
+- **tufte, ludus, tmsce, inkwell.latex**: no `\\iflanguage` or babel issues.
+- **eth-report**: self-contained `[ngerman, english]{babel}` load; unaffected.
+- **kth-letter**: already uses `\\@ifpackageloaded{babel}` guards; unaffected.
+
 ## 0.2.10 (2026-04-19)
 
 - **Preview: stop regex transforms from eating the blank line after a `{#label}` attribute.** The body pre-processors used `\s*$` with the `/m` flag when stripping Pandoc attribute blocks (heading `{#sec:...}`, table caption `{#tbl:...}`, `:::` fenced-div refs slot, and the catch-all trailing-attrs sweep). JavaScript's `\s` matches `\n`, so a greedy `\s*$` consumed the blank line *after* the attribute and glued the next markdown block onto the previous one. Downstream, markdown-it saw a `<figcaption>...</figcaption>` on one line immediately followed by `## Heading` and `1. List item`, which triggers CommonMark's HTML-block rule: the heading and the list got swallowed into the HTML block and were rendered as literal text instead of as a heading and an ordered list. Replace `\s*$` with `[ \t]*$` (and similarly for the leading side where present) so only horizontal whitespace is consumed, preserving the blank line that markdown-it needs as a block separator.

--- a/guide.md
+++ b/guide.md
@@ -722,3 +722,57 @@ Do not convert these; Inkwell passes raw LaTeX through to the PDF engine:
 **Two-column table overflow.** Two-column templates automatically shrink tables to fit. If a table still overflows, reduce the number of columns or use abbreviations in headers.
 
 **Long code lines.** Code blocks automatically wrap long lines in the PDF. Use `code-font-size: footnotesize` or `code-font-size: scriptsize` if lines are still too wide.
+
+## Troubleshooting
+
+Run **Inkwell: Check / Install Toolchain** from the command palette first — it diagnoses all of the conditions below and surfaces one-click remediations for most of them. The list here is a reference for what those messages mean.
+
+### Compile fails with "You haven't defined the language 'spanish' yet"
+
+Affects the **rho** and **rmxaa** templates on TinyTeX / BasicTeX installs. Fixed in Inkwell 0.3.0+ by loading Spanish alongside English in the template wrappers. If you see this on an older version, upgrade the extension (`brew upgrade --cask inkwell`) or add `babel-spanish` and `hyphen-spanish` to your local `requirements-latex.txt` and run **Inkwell: Check / Install Toolchain**.
+
+### Compile fails with "File 'xstring.sty' not found" (or fixtounicode, fix2col, ...)
+
+Your TeX distribution is missing a package that a shipped template depends on. On a clean TinyTeX install these are not present by default; the full package list ships in `requirements-latex.txt`. Run **Inkwell: Check / Install Toolchain** → *Install packages with tlmgr*, or run the command directly:
+
+```bash
+sed 's/#.*//' <path-to-requirements-latex.txt> | awk 'NF' | xargs tlmgr install
+texhash || mktexlsr
+```
+
+### Compiled PDF shows "??" where cross-references should be
+
+Affects any document that uses `@fig:`, `@tbl:`, `@eq:`, `@sec:`, `\ref{…}`, `\pageref{LastPage}`, or `\tableofcontents`. Fixed in Inkwell 0.3.0+: the compile pipeline now runs the engine twice so LaTeX can resolve cross-references via `.aux`. If you still see `??` on an older version, compile twice in a row (the second run will resolve) or upgrade.
+
+### tlmgr install succeeds but compile still reports "file not found"
+
+Symptom of a root-owned TeX tree. Common after:
+
+- Bootstrapping TinyTeX with `curl … | sudo sh`
+- Copying a `~/Library/TinyTeX/` tree from another machine
+- Running an aborted `brew install --cask basictex` as root
+
+When the TEXMFROOT directory is owned by a user other than the one running Inkwell, `tlmgr install` as your user fails to update the `ls-R` file index — the packages are on disk but `kpsewhook` can't find them. The extension detects this in **Inkwell: Check / Install Toolchain** and offers a one-click fix. Manually:
+
+```bash
+sudo chown -R "$USER" "$(kpsewhich -var-value TEXMFROOT)"
+texhash
+```
+
+Re-run the toolchain check afterward to confirm.
+
+### Preview shows raw LaTeX syntax instead of rendered output
+
+Reload the editor window: `Cmd+Shift+P` → **Developer: Reload Window**. After a `brew upgrade --cask inkwell`, VS Code / Cursor keeps the old extension code loaded in memory until the window reloads.
+
+### I want to see the exact pandoc / xelatex invocation
+
+Open the **Inkwell** output channel (*View* > *Output* > *Inkwell* in the dropdown). Every compile logs the full `pandoc` argv, resolved `TEXINPUTS`, and `--resource-path` so you can reproduce the failure outside the extension without reading the bundle. Each engine pass is logged separately.
+
+### Mermaid diagrams show as code in the PDF
+
+Install the Mermaid CLI globally: `npm install -g @mermaid-js/mermaid-cli`. Inkwell shells out to `mmdc` to rasterize each diagram; without it, the fenced code survives to the PDF unrendered. **Inkwell: Check / Install Toolchain** flags this when it's missing.
+
+### Preview and PDF agree but differ from what I expect
+
+Preview is an HTML simulation of what LaTeX will produce. For structural correctness (refs, bibliography, numbering) preview and PDF should match post-compile. Visual differences (font, spacing, column breaks) are inherent to the two rendering engines — the PDF is authoritative for layout; the preview is authoritative for write-time feedback.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.2.10",
+  "version": "0.3.0",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/requirements-latex.txt
+++ b/requirements-latex.txt
@@ -8,6 +8,15 @@
 geometry
 hyperref
 babel
+# Spanish language files. Required by the rho and rmxaa templates even
+# when the document is authored in English: rhobabel.sty contains
+# \iflanguage{spanish}{...}{...} branches, and \iflanguage is a hard
+# error when the language is not declared to babel. babel-spanish
+# provides the language definition; hyphen-spanish prevents "No
+# hyphenation patterns were preloaded for Spanish" warnings from
+# turning into run-length pagination drift.
+babel-spanish
+hyphen-spanish
 iftex
 
 # layout and formatting
@@ -67,6 +76,14 @@ silence
 pbalance
 extsizes
 fixtounicode
+# Required by the default pandoc --template flow (the LaTeX that
+# pandoc emits for our markdown uses \xs@string operations on TinyTeX
+# minimal installs that otherwise report "File `xstring.sty' not
+# found"). fix2col is a defensive dependency for twocolumn templates
+# (rho, rmxaa) whose class files pull it in through the extarticle
+# chain; on minimal TinyTeX installs it is not present by default.
+xstring
+fix2col
 
 # bundles (provide multiple .sty files each)
 # amsfonts -> amssymb.sty, amsfonts.sty

--- a/scripts/install-inkwell-macos.sh
+++ b/scripts/install-inkwell-macos.sh
@@ -96,6 +96,29 @@ else
   echo "Skipping tlmgr package pass (tlmgr or requirements file not found)."
 fi
 
+# Ownership check. A curl | sudo sh bootstrap of TinyTeX (or an aborted
+# BasicTeX install that left an intermediate root-owned state) leaves
+# the TeX tree owned by root. Subsequent tlmgr installs succeed as
+# root but the ls-R index update fails silently when the user later
+# tries to compile, producing the "File 'xstring.sty' not found" class
+# of errors even though the file sits right there on disk. Detect that
+# state now and offer a one-line remediation before the user ever
+# hits it from the extension.
+if has_cmd kpsewhich; then
+  TEX_ROOT="$(kpsewhich -var-value TEXMFROOT 2>/dev/null || true)"
+  if [[ -n "$TEX_ROOT" && -d "$TEX_ROOT" ]]; then
+    TEX_OWNER="$(stat -f '%Su' "$TEX_ROOT" 2>/dev/null || true)"
+    if [[ -n "$TEX_OWNER" && "$TEX_OWNER" != "$USER" ]]; then
+      echo ""
+      echo "WARNING: TEXMFROOT ($TEX_ROOT) is owned by '$TEX_OWNER' but you are '$USER'."
+      echo "This breaks 'tlmgr install' silently: packages install but never register in the file index."
+      echo "Run this to fix:"
+      echo "    sudo chown -R \"$USER\" \"$TEX_ROOT\" && \"$TEX_ROOT/bin/universal-darwin/texhash\""
+      echo ""
+    fi
+  fi
+fi
+
 echo ""
 echo "Inkwell setup complete."
 echo "Next steps:"

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -413,6 +413,15 @@ async function compilePandoc(
   const tmpSource = path.join(cacheDir, path.basename(sourceFile));
   fs.writeFileSync(tmpSource, injected, "utf-8");
 
+  // Two-stage compile:
+  //   1. pandoc  ->  .tex  (runs the template, pandoc-crossref, citeproc)
+  //   2. engine  ->  .pdf  (run twice so \ref / \pageref / \tableofcontents
+  //                         and pandoc-crossref's internal refs resolve)
+  // The single-pass `pandoc --pdf-engine=...` flow only ran the engine
+  // once, which produced ? marks and \pageref{LastPage} showing as
+  // "??" on every first compile. Two passes is the documented minimum
+  // for LaTeX cross-reference resolution.
+  const tmpTex = path.join(cacheDir, `${baseName}.tex`);
   const tmpOutput = path.join(cacheDir, `${baseName}.pdf`);
 
   const ext = path.extname(sourceFile).toLowerCase();
@@ -424,11 +433,10 @@ async function compilePandoc(
   const projectRoot = getInkwellProjectRoot(sourceFile);
   const resourcePath = [cacheDir, template.dir, sourceDir, projectRoot].join(":");
 
-  const args = [
+  const pandocArgs = [
     tmpSource,
     "-o",
-    tmpOutput,
-    `--pdf-engine=${engine}`,
+    tmpTex,
     "--standalone",
     `--template=${templateDst}`,
     `--from=${fromFormat}`,
@@ -444,26 +452,26 @@ async function compilePandoc(
 
   const preambleFile = writePreambleFile(rawText, cacheDir);
   if (preambleFile) {
-    args.push("-H", preambleFile);
+    pandocArgs.push("-H", preambleFile);
   }
 
   const crossref = await findBinary("pandoc-crossref");
   if (crossref) {
-    const citeprocIndex = args.indexOf("--citeproc");
+    const citeprocIndex = pandocArgs.indexOf("--citeproc");
     if (citeprocIndex >= 0) {
-      args.splice(citeprocIndex, 0, "--filter", crossref);
+      pandocArgs.splice(citeprocIndex, 0, "--filter", crossref);
     } else {
-      args.push("--filter", crossref);
+      pandocArgs.push("--filter", crossref);
     }
   }
 
   const bibFiles = findBibFiles(projectRoot);
   for (const bib of bibFiles) {
-    args.push("--bibliography", bib);
+    pandocArgs.push("--bibliography", bib);
   }
   const defaults = findDefaultsYaml(projectRoot);
   if (defaults) {
-    args.push("--defaults", defaults);
+    pandocArgs.push("--defaults", defaults);
   }
 
   copySiblingFiles(sourceDir, projectRoot, cacheDir);
@@ -492,23 +500,103 @@ async function compilePandoc(
     `[inkwell] cls in template dir: ${fs.existsSync(clsExpected)}`,
     `[inkwell] cls in cache dir: ${fs.existsSync(clsCached)}`,
     `[inkwell] engine: ${engine}`,
-    `[inkwell] pandoc args: ${args.join(" ")}`,
+    `[inkwell] pandoc argv: ${pandoc} ${pandocArgs.map((a) => (a.includes(" ") ? `"${a}"` : a)).join(" ")}`,
     `[inkwell] cache bib exists: ${fs.existsSync(cacheBib)}`,
     `[inkwell] cache dir contents: ${(() => { try { return fs.readdirSync(cacheDir).join(", "); } catch { return "error"; } })()}`,
     ...featureCheck.logLines,
   ].join("\n");
 
+  // Stage 1: pandoc -> .tex
   try {
-    const result = await exec(pandoc, args, {
+    const result = await exec(pandoc, pandocArgs, {
       cwd: sourceDir,
-      timeout: 120_000,
+      timeout: 60_000,
       env: texEnv,
     });
-    stdout = result.stdout;
-    stderr = result.stderr;
+    stdout += result.stdout;
+    stderr += result.stderr;
   } catch (err: any) {
-    if (err.stderr) stderr = err.stderr;
-    if (err.stdout) stdout = err.stdout;
+    if (err.stderr) stderr += err.stderr;
+    if (err.stdout) stdout += err.stdout;
+  }
+
+  const texExists = fs.existsSync(tmpTex);
+  let logContent = "";
+
+  // Stage 2: engine -> .pdf, run twice to resolve cross-references.
+  // Skip if pandoc failed to produce the .tex.
+  if (texExists) {
+    const engineArgs = [
+      "-interaction=nonstopmode",
+      "-halt-on-error",
+      `-output-directory=${cacheDir}`,
+      tmpTex,
+    ];
+
+    for (let pass = 0; pass < 2; pass++) {
+      stdout += `\n[inkwell] ${engine} pass ${pass + 1}: ${engine} ${engineArgs.join(" ")}\n`;
+      try {
+        const result = await exec(engine, engineArgs, {
+          cwd: sourceDir,
+          timeout: 90_000,
+          env: texEnv,
+        });
+        stdout += result.stdout;
+        stderr += result.stderr;
+      } catch (err: any) {
+        if (err.stdout) stdout += err.stdout;
+        if (err.stderr) stderr += err.stderr;
+        // First-pass failures are expected (undefined refs, missing
+        // aux entries). Continue to pass 2 in that case; it typically
+        // resolves. Only a pass-2 failure is a real compile error.
+        if (pass === 0) continue;
+      }
+    }
+
+    // Bibliography handling for the raw-\cite path. Pandoc's
+    // --citeproc inlines CSL entries directly, so in the typical
+    // Inkwell flow we have no \bibliography / \addbibresource in
+    // the generated .tex and biber/bibtex are unneeded. A user with
+    // raw LaTeX \cite commands still gets served: we detect the
+    // macro in the generated .tex and run biber/bibtex + one more
+    // engine pass in that case.
+    try {
+      const texContent = fs.readFileSync(tmpTex, "utf-8");
+      const hasBib = /\\(bibliography|addbibresource)\{/.test(texContent);
+      if (hasBib) {
+        const biber = await findBinary("biber");
+        const bibtex = await findBinary("bibtex");
+        const bibTool = biber || bibtex;
+        if (bibTool) {
+          try {
+            await exec(bibTool, [path.join(cacheDir, baseName)], {
+              cwd: cacheDir,
+              timeout: 30_000,
+              env: texEnv,
+            });
+          } catch (err: any) {
+            if (err.stderr) stderr += "\n" + err.stderr;
+          }
+          try {
+            const r = await exec(engine, engineArgs, {
+              cwd: sourceDir,
+              timeout: 90_000,
+              env: texEnv,
+            });
+            stdout += r.stdout;
+            stderr += r.stderr;
+          } catch (err: any) {
+            if (err.stderr) stderr += err.stderr;
+            if (err.stdout) stdout += err.stdout;
+          }
+        }
+      }
+    } catch {}
+
+    const logFile = path.join(cacheDir, `${baseName}.log`);
+    try {
+      logContent = fs.readFileSync(logFile, "utf-8");
+    } catch {}
   }
 
   const pdfExists = fs.existsSync(tmpOutput);
@@ -516,14 +604,17 @@ async function compilePandoc(
     fs.copyFileSync(tmpOutput, pdfOutput);
   }
 
-  const errors = [...featureCheck.warnings, ...parseErrors(stderr, stdout)];
+  const errors = [
+    ...featureCheck.warnings,
+    ...parseErrors(stderr + "\n" + logContent, stdout),
+  ];
   const duration = (Date.now() - start) / 1000;
 
   return {
     success: pdfExists,
     pdfPath: pdfExists ? pdfOutput : undefined,
     errors,
-    log: diagnosticLog + "\n\n" + stderr + "\n" + stdout,
+    log: diagnosticLog + "\n\n" + stderr + "\n" + stdout + (logContent ? "\n\n--- engine log ---\n" + logContent.slice(-8000) : ""),
     duration,
   };
 }

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -21,6 +21,14 @@ export interface ToolchainStatus {
   mmdc: { installed: boolean; version?: string; path?: string };
   texDistribution?: "full" | "basic" | "tinytex" | "unknown";
   missingPackages: string[];
+  /** Path of the TEXMFROOT resolved via kpsewhich, when available. */
+  texRoot?: string;
+  /** True when the TEXMFROOT tree is writable by the current user. */
+  texRootWritable?: boolean;
+  /** Owner of TEXMFROOT (resolved via stat -f / stat -c). */
+  texRootOwner?: string;
+  /** The current process user, for comparison. */
+  currentUser?: string;
 }
 
 let _extensionPath = "";
@@ -60,6 +68,13 @@ const FALLBACK_PACKAGES = [
   "supertabular", "matlab-prettifier", "lipsum", "hardwrap",
   "units", "silence",
   "pbalance", "extsizes", "fixtounicode",
+  // Required by the rho / rmxaa templates even in English documents:
+  // rhobabel.sty calls \iflanguage{spanish} which hard-errors when
+  // the language is not declared to babel.
+  "babel-spanish", "hyphen-spanish",
+  // Hit on minimal TinyTeX installs during the default pandoc
+  // --template flow.
+  "xstring", "fix2col",
   "amsfonts", "amscls", "tools", "preprint", "sttools",
   "graphics", "oberdiek", "psnfss",
   "mathpazo", "palatino", "bera", "soul", "stix2-type1", "tex-gyre",
@@ -217,6 +232,11 @@ async function checkLatexPackages(kpsewhich: string | undefined): Promise<string
     } catch {}
   }
 
+  // Packages whose primary installed file does not match the default
+  // "<package>.sty" heuristic. Without these mappings, kpsewhich
+  // returns empty for the generated filename and the probe falsely
+  // reports the package as missing, which then triggers a tlmgr
+  // reinstall on every Check Toolchain run.
   const packageFiles: Record<string, string> = {
     "tufte-latex": "tufte-handout.cls",
     "bera": "beramono.sty",
@@ -232,6 +252,12 @@ async function checkLatexPackages(kpsewhich: string | undefined): Promise<string
     "oberdiek": "iflang.sty",
     "psnfss": "helvet.sty",
     "extsizes": "extarticle.cls",
+    "babel-spanish": "spanish.ldf",
+    // hyphen-spanish installs hyphenation patterns, not a .sty file.
+    // kpsewhich resolves the format-file-embedded pattern through the
+    // language.dat chain; the file that reliably shows up is loadhyph-es.tex.
+    "hyphen-spanish": "loadhyph-es.tex",
+    "fix2col": "fix2col.sty",
   };
 
   const missing: string[] = [];
@@ -256,6 +282,53 @@ async function checkLatexPackages(kpsewhich: string | undefined): Promise<string
   return missing;
 }
 
+/**
+ * Resolve TEXMFROOT, its owner, and whether the current user can write
+ * to it. A root-owned TEXMFROOT (common after curl|sudo sh installs of
+ * TinyTeX) silently breaks tlmgr: packages install into a writable
+ * location but texhash / mktexlsr fail to update the root ls-R index,
+ * so kpsewhich continues to report the newly-installed files as
+ * absent. Detecting the ownership mismatch up front lets us surface
+ * an actionable "Fix TinyTeX permissions" remediation instead of
+ * looping the user through a "tlmgr install ... retry compile" cycle
+ * that never resolves.
+ */
+async function inspectTexRoot(kpsewhich: string | undefined): Promise<{
+  texRoot?: string;
+  texRootWritable?: boolean;
+  texRootOwner?: string;
+  currentUser?: string;
+}> {
+  if (!kpsewhich) return {};
+  let texRoot: string | undefined;
+  try {
+    const { stdout } = await exec(kpsewhich, ["-var-value", "TEXMFROOT"], { timeout: 5000 });
+    texRoot = stdout.trim();
+  } catch {
+    return {};
+  }
+  if (!texRoot || !fs.existsSync(texRoot)) return { texRoot };
+
+  const currentUser = process.env.USER || os.userInfo().username;
+  let texRootOwner: string | undefined;
+  try {
+    const statArgs = isMac ? ["-f", "%Su", texRoot] : ["-c", "%U", texRoot];
+    const { stdout } = await exec("stat", statArgs, { timeout: 5000 });
+    texRootOwner = stdout.trim();
+  } catch {}
+
+  // fs.accessSync with W_OK on a dir is the cross-platform signal for
+  // "can this user add files here"; it returns true for the root user
+  // case we actually care about (user != owner).
+  let texRootWritable = false;
+  try {
+    fs.accessSync(texRoot, fs.constants.W_OK);
+    texRootWritable = true;
+  } catch {}
+
+  return { texRoot, texRootWritable, texRootOwner, currentUser };
+}
+
 export async function checkToolchain(): Promise<ToolchainStatus> {
   const [pandoc, xelatex, pdflatex, crossref, mmdc] = await Promise.all([
     probe("pandoc"),
@@ -269,6 +342,7 @@ export async function checkToolchain(): Promise<ToolchainStatus> {
   const missingPackages = xelatex.installed
     ? await checkLatexPackages(kpsewhich)
     : [];
+  const rootInfo = xelatex.installed ? await inspectTexRoot(kpsewhich) : {};
 
   return {
     pandoc,
@@ -278,6 +352,7 @@ export async function checkToolchain(): Promise<ToolchainStatus> {
     mmdc,
     texDistribution: detectDistribution(xelatex.path),
     missingPackages,
+    ...rootInfo,
   };
 }
 
@@ -334,6 +409,25 @@ export async function showToolchainStatus(): Promise<void> {
     lines.push(`LaTeX packages: ${missingCount} missing (${status.missingPackages.slice(0, 5).join(", ")}${missingCount > 5 ? ", ..." : ""})`);
   }
 
+  // Ownership check: if the TEXMFROOT is owned by a user other than
+  // the one running Inkwell and is not writable, packages installed
+  // via tlmgr cannot be registered in the ls-R index and will still
+  // be "not found" at compile time. This is almost always the result
+  // of a `curl ... | sudo sh` TinyTeX bootstrap and is the hardest
+  // failure to diagnose from the compile log alone.
+  const ownershipBroken =
+    status.xelatex.installed &&
+    status.texRoot &&
+    status.texRootOwner &&
+    status.currentUser &&
+    status.texRootOwner !== status.currentUser &&
+    status.texRootWritable === false;
+  if (ownershipBroken) {
+    lines.push(
+      `TEXMFROOT permission: ${status.texRoot} is owned by "${status.texRootOwner}" but you are "${status.currentUser}". tlmgr installs will not register in the file index.`,
+    );
+  }
+
   const coreReady =
     status.pandoc.installed &&
     status.xelatex.installed &&
@@ -341,7 +435,7 @@ export async function showToolchainStatus(): Promise<void> {
     status.crossref.installed;
   const allGood = coreReady && missingCount === 0;
 
-  if (allGood) {
+  if (allGood && !ownershipBroken) {
     const mmdcNote = status.mmdc.installed
       ? ""
       : "\n(mmdc not found; mermaid diagrams will render as code in PDFs)";
@@ -350,6 +444,29 @@ export async function showToolchainStatus(): Promise<void> {
       "OK"
     );
     return;
+  }
+
+  // Surface the ownership mismatch BEFORE the "install packages"
+  // prompt, because no amount of re-running tlmgr will fix the
+  // underlying index problem.
+  if (ownershipBroken) {
+    const fixCommand = `sudo chown -R "${status.currentUser}" "${status.texRoot}" && "${path.join(status.texRoot!, isMac ? "bin/universal-darwin" : "bin")}/texhash" || sudo texhash`;
+    const choice = await vscode.window.showErrorMessage(
+      `TEXMFROOT ownership mismatch: ${status.texRoot} is owned by "${status.texRootOwner}" but you are running as "${status.currentUser}". tlmgr installs succeed silently but newly-installed packages never register in the file index, so compile continues to fail with "file not found" errors even after you run "Install packages".`,
+      "Open terminal with fix command",
+      "Show details",
+      "Ignore",
+    );
+    if (choice === "Open terminal with fix command") {
+      const terminal = vscode.window.createTerminal("Inkwell: Fix TinyTeX permissions");
+      terminal.show();
+      terminal.sendText(fixCommand);
+      return;
+    } else if (choice === "Show details") {
+      showOwnershipDetails(status, fixCommand);
+      return;
+    }
+    // "Ignore": fall through to other remediation options.
   }
 
   // Core tools missing
@@ -440,6 +557,27 @@ export async function installLatexPackage(packageName: string): Promise<void> {
     return;
   }
   await installMissingPackages([normalized]);
+}
+
+function showOwnershipDetails(status: ToolchainStatus, fixCommand: string): void {
+  const doc: string[] = ["# Inkwell: TeX tree owned by a different user\n"];
+  doc.push(`**TEXMFROOT**: \`${status.texRoot}\``);
+  doc.push(`**Owner**: ${status.texRootOwner}`);
+  doc.push(`**Running as**: ${status.currentUser}`);
+  doc.push(`**User can write to the tree**: ${status.texRootWritable ? "yes" : "no"}\n`);
+  doc.push("## Why this breaks your compile\n");
+  doc.push(
+    "A TeX installation bootstrapped with `sudo` (most commonly `curl ... | sudo sh` for TinyTeX) ends up owned by root. `tlmgr install <pkg>` will still succeed when you run it with `sudo`, but the subsequent `texhash` / `mktexlsr` call cannot update the root ls-R index as a non-root user, so `kpsewhich` continues to report every newly-installed package as absent. Every compile then fails with `File '<pkg>.sty' not found` even though the file is sitting in the tree.",
+  );
+  doc.push("\n## Fix\n");
+  doc.push("Change the owner of the tree to your user, then regenerate the file index:\n");
+  doc.push("```bash");
+  doc.push(fixCommand);
+  doc.push("```\n");
+  doc.push("Re-run **Inkwell: Check / Install Toolchain** after running the fix to confirm the green state.");
+  vscode.workspace
+    .openTextDocument({ content: doc.join("\n"), language: "markdown" })
+    .then((d) => vscode.window.showTextDocument(d));
 }
 
 function showPackageDetails(status: ToolchainStatus): void {

--- a/templates/rho/rho.latex
+++ b/templates/rho/rho.latex
@@ -4,7 +4,17 @@
 % We add only what Pandoc requires for syntax highlighting and tables.
 
 \documentclass[$for(classoption)$$classoption$$sep$,$endfor$$if(classoption)$$else$9pt,a4paper,twoside$endif$]{rho-class/rho}
-\usepackage[english]{babel}
+% Load spanish alongside english. The rho class's rhobabel.sty calls
+% \iflanguage{spanish}{...}{...} in ~20 places; \iflanguage is a hard
+% error (not a silent false) when the referenced language has not been
+% declared. On TinyTeX / BasicTeX installs, where Spanish is not
+% preloaded into the format file, this otherwise crashes every rho
+% compile with "You haven't defined the language 'spanish' yet". Full
+% MacTeX users got lucky because babel-spanish ships with mactex. The
+% babel-spanish + hyphen-spanish packages must also be installed; they
+% live in requirements-latex.txt for tlmgr. english remains the primary
+% language (last option in the list wins).
+\usepackage[spanish,english]{babel}
 
 \setbool{rho-abstract}{$if(abstract)$true$else$false$endif$}
 \setbool{corres-info}{$if(corres)$true$else$$if(email)$true$else$$if(doi)$true$else$false$endif$$endif$$endif$}

--- a/templates/rmxaa/rmxaa.latex
+++ b/templates/rmxaa/rmxaa.latex
@@ -9,6 +9,14 @@
 
 \documentclass[$for(classoption)$$classoption$$sep$,$endfor$$if(classoption)$$else$9pt,twoside$endif$]{rmaa-rho-class/rmaa-rho}
 
+% Load spanish alongside english. rmaa-rho/rhobabel.sty contains
+% \iflanguage{spanish}{...}{...} branches that hard-error when the
+% language has not been declared to babel. On TinyTeX / BasicTeX this
+% otherwise crashes every rmxaa compile. See templates/rho/rho.latex
+% for the same fix applied to the rho template. english remains the
+% primary language (last option wins).
+\usepackage[spanish,english]{babel}
+
 % Pandoc citeproc manages the bibliography; suppress natbib's
 % author-year format check, which rejects citeproc's \bibitem entries.
 % The cls loads natbib[authoryear,numbers] and registers an


### PR DESCRIPTION
## Summary

Reliability release. Addresses five classes of failure observed during automated PDF rebuilds on a clean TinyTeX install. Scoped to the report you filed.

### Fixed

- **rho + rmxaa templates: \`\\iflanguage{spanish}\` crashes on babel-english-only installs.** Both template classes call \`\\iflanguage{spanish}{...}{...}\` in their \`rhobabel.sty\` helpers. \`\\iflanguage\` is a hard error when the language has not been declared to babel. The wrappers previously loaded \`\\usepackage[english]{babel}\` only, which crashed compile on TinyTeX / BasicTeX. Load \`[spanish,english]{babel}\`; add \`babel-spanish\` and \`hyphen-spanish\` to \`requirements-latex.txt\`. english remains the primary language.
- **Compile: two-pass engine resolution.** Replace the single-pass \`pandoc --pdf-engine=...\` flow with \`pandoc -> .tex\` then \`engine -> .pdf\` twice. Resolves \`\\ref\`, \`\\pageref{LastPage}\`, \`\\tableofcontents\`, and pandoc-crossref's internal refs on first compile. Biber / bibtex fallback for raw-LaTeX \`\\cite\` paths.
- **Missing packages on clean TinyTeX.** Add \`xstring\`, \`fix2col\`, \`babel-spanish\`, \`hyphen-spanish\` to the shipped requirements list and the toolchain fallback. Map them in the \`kpsewhich\` probe so they report accurately instead of always showing missing.

### Added

- **Toolchain: TEXMFROOT ownership check.** Detects the silent-failure mode of TinyTeX bootstrapped via \`curl ... | sudo sh\`, where \`tlmgr install\` succeeds but \`kpsewhich\` never sees the files because \`ls-R\` can't be updated as a non-root user. Surfaces an actionable \`sudo chown\` remediation before the package-install prompt.
- **Install script: post-install ownership warning.** Same check in \`scripts/install-inkwell-macos.sh\` with the exact fix command.
- **Full pandoc / engine argv in the output channel.** Each compile logs its complete invocation, \`TEXINPUTS\`, and \`--resource-path\` in reproducible form.
- **\`guide.md\` Troubleshooting section.** Documents every failure mode and its remediation, plus the post-\`brew upgrade\` reload reminder and where to find the compile invocation.

### Template audit

| Template     | Status          |
|--------------|-----------------|
| rho          | Fixed (babel)   |
| rmxaa        | Fixed (babel)   |
| tufte        | Unaffected      |
| ludus        | Unaffected      |
| tmsce        | Unaffected      |
| eth-report   | Unaffected (self-contained babel) |
| kth-letter   | Unaffected (\\@ifpackageloaded guard) |
| inkwell      | Unaffected      |

## Test plan

- [x] \`npm run verify\`
- [x] \`npm run package\` (295.6 kb bundle)
- [ ] Reviewer: on a machine without full MacTeX (TinyTeX is ideal), run Compile on a rho or rmxaa document. Expect: no \`You haven't defined the language 'spanish' yet\`; first-compile PDF with no \`??\` cross-references; Page 1 of N correctly resolved.
- [ ] Reviewer: \`sudo chown -R root ~/Library/TinyTeX\`, then **Inkwell: Check / Install Toolchain** \u2014 expect the ownership mismatch prompt with a one-click remediation. Revert with \`sudo chown -R "$USER" ~/Library/TinyTeX\` afterward.