### PR TITLE
feat: full toolchain check + CI regression compile (v0.3.1)

### DIFF
--- a/.github/workflows/compile-demos.yml
+++ b/.github/workflows/compile-demos.yml
@@ -110,6 +110,45 @@ jobs:
             exit 1
           fi
 
+      - name: Seed runtime-generated figures
+        run: |
+          # demo-tufte references .inkwell/figures/anscombe.pdf which
+          # is produced by a Python block in the demo. Under the
+          # extension, users run the block (Cmd+Alt+R) before
+          # compiling. In CI we skip the code-block runner and just
+          # generate the figures directly with matplotlib so the
+          # compile pipeline can be tested in isolation. Add new
+          # seed calls here when new demos introduce runtime-generated
+          # figures; alternatively, commit a placeholder under
+          # .inkwell/figures/ and exclude the file from .gitignore.
+          python3 -m pip install --quiet matplotlib numpy
+          mkdir -p .inkwell/figures
+          python3 - <<'PY'
+          import matplotlib
+          matplotlib.use("Agg")
+          import matplotlib.pyplot as plt
+          import numpy as np
+
+          # Anscombe's quartet. Minimal reproduction, not the demo's
+          # exact visual.
+          datasets = {
+              "I":  ([10,8,13,9,11,14,6,4,12,7,5], [8.04,6.95,7.58,8.81,8.33,9.96,7.24,4.26,10.84,4.82,5.68]),
+              "II": ([10,8,13,9,11,14,6,4,12,7,5], [9.14,8.14,8.74,8.77,9.26,8.10,6.13,3.10,9.13,7.26,4.74]),
+              "III":([10,8,13,9,11,14,6,4,12,7,5], [7.46,6.77,12.74,7.11,7.81,8.84,6.08,5.39,8.15,6.42,5.73]),
+              "IV": ([8,8,8,8,8,8,8,19,8,8,8],    [6.58,5.76,7.71,8.84,8.47,7.04,5.25,12.50,5.56,7.91,6.89]),
+          }
+          fig, axes = plt.subplots(2, 2, figsize=(6.5, 5.5))
+          for ax, (name, (x, y)) in zip(axes.flat, datasets.items()):
+              ax.scatter(x, y, s=22, alpha=0.8)
+              m, b = np.polyfit(x, y, 1)
+              xs = np.array(sorted(x))
+              ax.plot(xs, m*xs+b, linewidth=1)
+              ax.set_title(f"Dataset {name}")
+              ax.set_xlim(2, 20); ax.set_ylim(2, 14)
+          fig.tight_layout()
+          fig.savefig(".inkwell/figures/anscombe.pdf", bbox_inches="tight")
+          PY
+
       - name: Compile every demo
         run: |
           export PATH="$HOME/.TinyTeX/bin/x86_64-linux:$PATH"

--- a/.github/workflows/compile-demos.yml
+++ b/.github/workflows/compile-demos.yml
@@ -90,7 +90,7 @@ jobs:
           # visible to kpsewhich after this step. The whole point of
           # the CI regression is to catch the case where they are not.
           missing=0
-          for probe in xstring.sty fix2col.sty spanish.ldf loadhyph-es.tex; do
+          for probe in xstring.sty fix2col.sty svn-prov.sty english.ldf spanish.ldf loadhyph-es.tex; do
             if kpsewhich "$probe" >/dev/null 2>&1; then
               echo "OK   kpsewhich $probe"
             else

--- a/.github/workflows/compile-demos.yml
+++ b/.github/workflows/compile-demos.yml
@@ -77,21 +77,30 @@ jobs:
           tlmgr update --self
           # Strip comments + blank lines from the requirements list and
           # install in bulk. The `| xargs` pattern matches what the
-          # extension's toolchain setup does.
-          sed 's/#.*//' requirements-latex.txt | awk 'NF' | xargs tlmgr install
-          texhash || mktexlsr
+          # extension's toolchain setup does. `tlmgr install` tolerates
+          # a non-zero exit here: TinyTeX sometimes fails the final
+          # fmtutil-sys regeneration for luametatex/luajittex engines
+          # the minimal install does not ship, even though every
+          # package it downloaded is on disk. The kpsewhich spot-check
+          # below is what actually verifies the install succeeded.
+          sed 's/#.*//' requirements-latex.txt | awk 'NF' | xargs tlmgr install || true
+          texhash || mktexlsr || true
           kpsewhich --version | head -1
           # Sanity check: the packages introduced in v0.3.0 should be
           # visible to kpsewhich after this step. The whole point of
           # the CI regression is to catch the case where they are not.
+          missing=0
           for probe in xstring.sty fix2col.sty spanish.ldf loadhyph-es.tex; do
             if kpsewhich "$probe" >/dev/null 2>&1; then
-              echo "OK  kpsewhich $probe"
+              echo "OK   kpsewhich $probe"
             else
               echo "FAIL kpsewhich $probe (not in TinyTeX after tlmgr pass)"
-              exit 1
+              missing=1
             fi
           done
+          if [[ "$missing" -ne 0 ]]; then
+            exit 1
+          fi
 
       - name: Compile every demo
         run: |

--- a/.github/workflows/compile-demos.yml
+++ b/.github/workflows/compile-demos.yml
@@ -1,0 +1,117 @@
+name: Compile demos
+
+# Regression compile of every shipped demo against a clean TinyTeX.
+# Catches the class of failures that only surface outside a Full MacTeX
+# install: templates that depend on babel-spanish, packages that ship
+# in mactex but not tinytex, cross-reference resolution that requires
+# two engine passes, etc.
+#
+# Runs on pull requests that touch a template, the requirements list,
+# or the compile pipeline, and on every push to main. Intentionally not
+# run on every PR to avoid a 10+ minute wait for unrelated changes.
+
+on:
+  pull_request:
+    paths:
+      - "templates/**"
+      - "requirements-latex.txt"
+      - "src/compiler.ts"
+      - "src/inject.ts"
+      - "scripts/compile-demo.sh"
+      - "scripts/compile-all-demos.sh"
+      - "examples/demo-*.md"
+      - ".github/workflows/compile-demos.yml"
+  push:
+    branches: [main]
+    paths:
+      - "templates/**"
+      - "requirements-latex.txt"
+      - "src/compiler.ts"
+      - "src/inject.ts"
+      - "scripts/compile-demo.sh"
+      - "scripts/compile-all-demos.sh"
+      - "examples/demo-*.md"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  compile-all-demos:
+    name: Compile every demo on TinyTeX
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install pandoc + pandoc-crossref
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+          # pandoc-crossref is not in apt; download the release binary.
+          set -e
+          crossref_url="$(curl -sL https://api.github.com/repos/lierdakil/pandoc-crossref/releases/latest \
+            | grep 'browser_download_url.*Linux-X64.tar.xz' | head -1 | cut -d '"' -f 4 || true)"
+          if [[ -n "$crossref_url" ]]; then
+            curl -sL "$crossref_url" -o /tmp/pandoc-crossref.tar.xz
+            mkdir -p /tmp/pc
+            tar -xJf /tmp/pandoc-crossref.tar.xz -C /tmp/pc
+            sudo mv /tmp/pc/pandoc-crossref /usr/local/bin/pandoc-crossref
+            sudo chmod +x /usr/local/bin/pandoc-crossref
+          else
+            echo "Could not resolve pandoc-crossref release; proceeding without it."
+          fi
+          pandoc --version | head -1
+          pandoc-crossref --version 2>/dev/null || true
+
+      - name: Install TinyTeX
+        run: |
+          curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh
+          echo "$HOME/.TinyTeX/bin/x86_64-linux" >> "$GITHUB_PATH"
+
+      - name: Install required LaTeX packages
+        run: |
+          export PATH="$HOME/.TinyTeX/bin/x86_64-linux:$PATH"
+          tlmgr update --self
+          # Strip comments + blank lines from the requirements list and
+          # install in bulk. The `| xargs` pattern matches what the
+          # extension's toolchain setup does.
+          sed 's/#.*//' requirements-latex.txt | awk 'NF' | xargs tlmgr install
+          texhash || mktexlsr
+          kpsewhich --version | head -1
+          # Sanity check: the packages introduced in v0.3.0 should be
+          # visible to kpsewhich after this step. The whole point of
+          # the CI regression is to catch the case where they are not.
+          for probe in xstring.sty fix2col.sty spanish.ldf loadhyph-es.tex; do
+            if kpsewhich "$probe" >/dev/null 2>&1; then
+              echo "OK  kpsewhich $probe"
+            else
+              echo "FAIL kpsewhich $probe (not in TinyTeX after tlmgr pass)"
+              exit 1
+            fi
+          done
+
+      - name: Compile every demo
+        run: |
+          export PATH="$HOME/.TinyTeX/bin/x86_64-linux:$PATH"
+          scripts/compile-all-demos.sh
+
+      - name: Upload PDFs on success
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiled-demos
+          path: examples/demo-*.pdf
+          if-no-files-found: warn
+
+      - name: Upload engine logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-logs
+          path: |
+            /tmp/inkwell-compile-*/*.log
+            /tmp/inkwell-compile-*/*.tex
+          if-no-files-found: warn

--- a/.github/workflows/compile-demos.yml
+++ b/.github/workflows/compile-demos.yml
@@ -46,12 +46,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Install pandoc + pandoc-crossref
+      - name: Install pandoc 3.x + pandoc-crossref
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pandoc
-          # pandoc-crossref is not in apt; download the release binary.
-          set -e
+          # Ubuntu 22.04's apt pandoc is 2.17 — below our minimum of
+          # 3.0 — and changes pandoc's --template handling enough that
+          # our compile pipeline's output differs from what a user on
+          # macOS with Homebrew pandoc 3.x produces. Install a pinned
+          # pandoc 3.x direct from the upstream release tarball so the
+          # CI matches what we actually target.
+          set -euo pipefail
+          PANDOC_VERSION="3.9"
+          curl -sL "https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb" -o /tmp/pandoc.deb
+          sudo dpkg -i /tmp/pandoc.deb
+          pandoc --version | head -1
+
+          # pandoc-crossref latest release binary.
           crossref_url="$(curl -sL https://api.github.com/repos/lierdakil/pandoc-crossref/releases/latest \
             | grep 'browser_download_url.*Linux-X64.tar.xz' | head -1 | cut -d '"' -f 4 || true)"
           if [[ -n "$crossref_url" ]]; then
@@ -60,11 +69,10 @@ jobs:
             tar -xJf /tmp/pandoc-crossref.tar.xz -C /tmp/pc
             sudo mv /tmp/pc/pandoc-crossref /usr/local/bin/pandoc-crossref
             sudo chmod +x /usr/local/bin/pandoc-crossref
+            pandoc-crossref --version | head -1
           else
             echo "Could not resolve pandoc-crossref release; proceeding without it."
           fi
-          pandoc --version | head -1
-          pandoc-crossref --version 2>/dev/null || true
 
       - name: Install TinyTeX
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.1 (2026-04-19)
+
+Follow-up to v0.3.0. Completes items 5 (full toolchain check) and 7 (CI regression compile) from the reliability backlog.
+
+### Added
+
+- **Toolchain: version-floor checks.** `pandoc --version` and `pandoc-crossref --version` are now parsed and compared against tested minimums (pandoc \u2265 3.0.0, pandoc-crossref \u2265 0.3.0). Older versions produce a yellow warning in **Inkwell: Check / Install Toolchain** with a one-click `brew upgrade` remediation. Unknown versions do not trigger the warning.
+- **Toolchain: automatic ls-R refresh when packages appear missing.** The package probe now runs in two passes: first against whatever state the file index happens to be in, then (only if anything is missing) after a `texhash` / `mktexlsr` refresh. Packages that transition from missing to found after the refresh were only missing because the index was stale, not because they were actually absent. The status line reports "rescued after running texhash; file index was stale" when this happens, so the user sees the cause instead of being stuck in a "tlmgr install, compile, still fails" loop.
+- **Toolchain: "Rebuild file index (texhash)"** button in the package-install prompt. Opens a terminal with the right `texhash` command (falls back to `sudo texhash` for root-owned trees).
+- **CI: compile-demos workflow.** `.github/workflows/compile-demos.yml` runs on every PR that touches a template, the requirements list, or the compile pipeline. Boots a fresh Ubuntu runner, installs pandoc + pandoc-crossref + TinyTeX, applies `requirements-latex.txt` via `tlmgr install`, probes the critical v0.3.0-added packages via `kpsewhich` to catch regressions in the package list itself, then compiles every `examples/demo-*.md` through the same two-stage (pandoc -> .tex, engine x 2) pipeline the extension uses. PDFs are uploaded as a workflow artifact on success; `.tex` and `.log` files are uploaded on failure. This catches exactly the class of failures the v0.3.0 release report identified \u2014 missing TinyTeX packages, unresolved cross-refs, babel-language crashes \u2014 before they ship.
+- **`scripts/compile-demo.sh`** and **`scripts/compile-all-demos.sh`.** Standalone reimplementations of the extension's compile pipeline. Used by the CI workflow; also useful locally when a user wants to reproduce an extension compile failure from the shell or debug a template change without firing up Cursor.
+- **`npm run test:installer`** now bash-syntax-checks the new demo-compile scripts in addition to the macOS installer.
+
 ## 0.3.0 (2026-04-19)
 
 Reliability release. Addresses five classes of failure observed during automated PDF rebuilds on a clean TinyTeX install. Every one of these produced a failing compile or a silently corrupted PDF on machines without a full MacTeX.

--- a/examples/demo-tufte.md
+++ b/examples/demo-tufte.md
@@ -143,6 +143,8 @@ When a table or figure demands the full page width, the \texttt{fullwidth}
 environment extends into the margin area. This is useful for wide tables
 or panoramic figures that lose clarity when constrained.
 
+\end{fullwidth}
+
 | Dataset | $n$ | $\bar{x}$ | $\bar{y}$ | $s_x$ | $s_y$ | $r$ |
 |---------|-----|-----------|-----------|--------|--------|-------|
 | I       | 11  | 9.0       | 7.50      | 3.32   | 2.03   | 0.816 |
@@ -151,8 +153,6 @@ or panoramic figures that lose clarity when constrained.
 | IV      | 11  | 9.0       | 7.50      | 3.32   | 2.03   | 0.816 |
 
 : Summary statistics of the Anscombe quartet. {#tbl:anscombe-stats}
-
-\end{fullwidth}
 
 # Mathematical Notation {#sec:math}
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inkwell",
   "displayName": "Inkwell",
   "description": "Markdown to publication-quality PDF. Live preview, Pandoc + XeLaTeX compilation, runnable code blocks, and LaTeX template management.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "measure-one",
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE",
@@ -191,7 +191,7 @@
     "lint": "eslint src --ext ts",
     "test:regressions": "node scripts/check-template-regressions.mjs",
     "test:stability": "node scripts/check-shortcuts-and-commands.mjs",
-    "test:installer": "bash -n scripts/install-inkwell-macos.sh",
+    "test:installer": "bash -n scripts/install-inkwell-macos.sh && bash -n scripts/compile-demo.sh && bash -n scripts/compile-all-demos.sh",
     "verify": "npm run typecheck && npm run lint && npm run test:regressions && npm run test:stability && npm run test:installer"
   },
   "dependencies": {

--- a/requirements-latex.txt
+++ b/requirements-latex.txt
@@ -8,6 +8,12 @@
 geometry
 hyperref
 babel
+# English language file. On a full TeX Live / MacTeX install this
+# ships with the base `babel` package. On a minimal TinyTeX install it
+# ships as a separate `babel-english` package, so rho / rmxaa / any
+# template that loads `\usepackage[english]{babel}` fails with
+# "Unknown option 'english'" until this is installed.
+babel-english
 # Spanish language files. Required by the rho and rmxaa templates even
 # when the document is authored in English: rhobabel.sty contains
 # \iflanguage{spanish}{...}{...} branches, and \iflanguage is a hard
@@ -76,6 +82,10 @@ silence
 pbalance
 extsizes
 fixtounicode
+# Required by `adforn` (rho's ornamental glyph package) which itself
+# pulls in `svn-prov.sty`. Minimal TinyTeX does not ship svn-prov in
+# the base install.
+svn-prov
 # Required by the default pandoc --template flow (the LaTeX that
 # pandoc emits for our markdown uses \xs@string operations on TinyTeX
 # minimal installs that otherwise report "File `xstring.sty' not

--- a/requirements-latex.txt
+++ b/requirements-latex.txt
@@ -121,6 +121,13 @@ bera
 soul
 stix2-type1
 tex-gyre
+# cm-super provides Type 1 versions of Computer Modern that microtype
+# can expand. Without it, pdftex reports:
+#   "pdfTeX error (font expansion): auto expansion is only possible
+#    with scalable fonts"
+# and refuses to produce a PDF. Hit by the eth-report template on
+# minimal TinyTeX.
+cm-super
 
 # ETH report dependencies
 koma-script

--- a/scripts/compile-all-demos.sh
+++ b/scripts/compile-all-demos.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Compile every examples/demo-*.md and fail if any compile errors.
+# Used by the compile-demos CI workflow and convenient for local
+# regression testing:
+#
+#   scripts/compile-all-demos.sh
+#
+# Exits non-zero if any demo fails. Prints a summary at the end.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+declare -a PASSED=()
+declare -a FAILED=()
+
+for demo in "$REPO_ROOT"/examples/demo-*.md; do
+  name="$(basename "$demo")"
+  echo ""
+  echo "━━━ $name ━━━"
+  if "$SCRIPT_DIR/compile-demo.sh" "$demo"; then
+    PASSED+=("$name")
+  else
+    FAILED+=("$name")
+  fi
+done
+
+echo ""
+echo "━━━ Summary ━━━"
+echo "passed: ${#PASSED[@]}"
+for n in "${PASSED[@]}"; do echo "  OK   $n"; done
+echo "failed: ${#FAILED[@]}"
+for n in "${FAILED[@]}"; do echo "  FAIL $n"; done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/compile-demo.sh
+++ b/scripts/compile-demo.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Compile a single demo Markdown file the same way the Inkwell
+# extension's compile pipeline does:
+#
+#   1. pandoc -> .tex  (template + pandoc-crossref filter + --citeproc)
+#   2. engine -> .pdf, twice (resolves \ref / \pageref / crossref)
+#   3. (only when the generated .tex uses \bibliography / \addbibresource)
+#      biber/bibtex + one more engine pass
+#
+# Used by scripts/compile-all-demos.sh and .github/workflows/compile-demos.yml
+# for CI regression testing, and by developers who need to reproduce
+# an extension compile failure from the shell without reading the
+# minified bundle.
+#
+# Usage:
+#   scripts/compile-demo.sh examples/demo-rho.md
+#   scripts/compile-demo.sh examples/demo-rho.md --keep-work  # preserve work dir
+#
+# Exit codes:
+#   0  compile succeeded, PDF produced
+#   1  pandoc failed
+#   2  engine failed to produce a PDF
+#   3  argument error
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <input.md> [--keep-work]" >&2
+  exit 3
+fi
+
+SRC="$1"
+KEEP_WORK="no"
+for arg in "${@:2}"; do
+  case "$arg" in
+    --keep-work) KEEP_WORK="yes" ;;
+    *) echo "Unknown flag: $arg" >&2; exit 3 ;;
+  esac
+done
+
+if [[ ! -f "$SRC" ]]; then
+  echo "File not found: $SRC" >&2
+  exit 3
+fi
+
+SRC_DIR="$(cd "$(dirname "$SRC")" && pwd)"
+SRC_BASE="$(basename "$SRC")"
+SRC_STEM="${SRC_BASE%.md}"
+SRC_ABS="$SRC_DIR/$SRC_BASE"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ── Discover the template from the frontmatter ───────────────────────
+# We read the YAML frontmatter manually so we do not need a YAML parser
+# in CI; only 'template:' is required. Match is case-sensitive and
+# tolerates quotes around the value.
+TEMPLATE="$(awk '
+  /^---$/ { fm = !fm; next }
+  fm && $1 == "template:" {
+    v = $2
+    gsub(/^[\"\x27]/, "", v)
+    gsub(/[\"\x27]$/, "", v)
+    print v
+    exit
+  }
+' "$SRC_ABS")"
+
+if [[ -z "$TEMPLATE" ]]; then
+  TEMPLATE="inkwell"
+fi
+
+TEMPLATE_DIR="$REPO_ROOT/templates/$TEMPLATE"
+TEMPLATE_LATEX="$TEMPLATE_DIR/$TEMPLATE.latex"
+if [[ "$TEMPLATE" == "inkwell" ]]; then
+  TEMPLATE_LATEX="$REPO_ROOT/templates/inkwell.latex"
+  TEMPLATE_DIR="$REPO_ROOT/templates"
+fi
+
+if [[ ! -f "$TEMPLATE_LATEX" ]]; then
+  echo "Template not found: $TEMPLATE_LATEX" >&2
+  exit 3
+fi
+
+# Resolve engine from the template's template.json.
+ENGINE="xelatex"
+if [[ -f "$TEMPLATE_DIR/template.json" ]]; then
+  ENGINE_FROM_JSON="$(awk -F'"' '/"engine"/ { print $4; exit }' "$TEMPLATE_DIR/template.json" || true)"
+  if [[ -n "$ENGINE_FROM_JSON" ]]; then
+    ENGINE="$ENGINE_FROM_JSON"
+  fi
+fi
+
+if ! command -v "$ENGINE" >/dev/null 2>&1; then
+  echo "Engine '$ENGINE' not on PATH" >&2
+  exit 3
+fi
+
+# ── Set up the work directory ────────────────────────────────────────
+WORK="$(mktemp -d -t inkwell-compile-XXXXXX)"
+cleanup() {
+  if [[ "$KEEP_WORK" == "no" ]]; then
+    rm -rf "$WORK"
+  else
+    echo "(work dir preserved at $WORK)" >&2
+  fi
+}
+trap cleanup EXIT
+
+cp "$SRC_ABS" "$WORK/"
+cp "$TEMPLATE_LATEX" "$WORK/"
+TEMPLATE_NAME="$(basename "$TEMPLATE_LATEX")"
+
+# Copy supporting files from the template dir (cls, sty, bst, figures,
+# logos). The real extension does this via copySupportingFiles; here
+# we match the behaviour by copying every non-README file.
+shopt -s nullglob
+for entry in "$TEMPLATE_DIR"/*; do
+  base="$(basename "$entry")"
+  case "$base" in
+    README.md|template.json|main.tex|sample_paper.tex) continue ;;
+  esac
+  cp -R "$entry" "$WORK/"
+done
+shopt -u nullglob
+
+# Copy bibliography files from the project's .inkwell/references/.
+mkdir -p "$WORK/.inkwell/references"
+if [[ -d "$REPO_ROOT/.inkwell/references" ]]; then
+  cp -R "$REPO_ROOT/.inkwell/references/." "$WORK/.inkwell/references/"
+fi
+
+# Pandoc extensions that the extension enables.
+PANDOC_EXTS="raw_tex+raw_attribute+tex_math_dollars+citations+footnotes+yaml_metadata_block+implicit_figures+link_attributes+fenced_divs+bracketed_spans+pipe_tables+smart"
+
+CROSSREF_BIN=""
+if command -v pandoc-crossref >/dev/null 2>&1; then
+  CROSSREF_BIN="$(command -v pandoc-crossref)"
+fi
+
+# Build pandoc args.
+PANDOC_ARGS=(
+  "$WORK/$SRC_BASE"
+  -o "$WORK/$SRC_STEM.tex"
+  --standalone
+  --template="$WORK/$TEMPLATE_NAME"
+  --from="markdown+$PANDOC_EXTS"
+  --resource-path="$WORK:$TEMPLATE_DIR:$SRC_DIR:$REPO_ROOT"
+  -V graphics=true
+  -V colorlinks=true
+  -V numbersections=true
+)
+
+if [[ -n "$CROSSREF_BIN" ]]; then
+  PANDOC_ARGS+=(--filter "$CROSSREF_BIN")
+fi
+PANDOC_ARGS+=(--citeproc)
+
+# Add all bib files from the project.
+shopt -s nullglob
+for bib in "$REPO_ROOT"/*.bib "$REPO_ROOT/references/"*.bib "$REPO_ROOT/.inkwell/references/"*.bib; do
+  if [[ -f "$bib" ]]; then
+    PANDOC_ARGS+=(--bibliography "$bib")
+  fi
+done
+shopt -u nullglob
+
+echo "[compile-demo] template=$TEMPLATE engine=$ENGINE"
+echo "[compile-demo] pandoc argv:"
+printf '  %q' pandoc "${PANDOC_ARGS[@]}"
+echo
+
+if ! pandoc "${PANDOC_ARGS[@]}"; then
+  echo "[compile-demo] pandoc failed" >&2
+  exit 1
+fi
+
+if [[ ! -f "$WORK/$SRC_STEM.tex" ]]; then
+  echo "[compile-demo] pandoc did not produce a .tex" >&2
+  exit 1
+fi
+
+export TEXINPUTS="$WORK:$TEMPLATE_DIR:$SRC_DIR:$REPO_ROOT:$REPO_ROOT/.inkwell:"
+
+ENGINE_ARGS=(
+  -interaction=nonstopmode
+  -halt-on-error
+  "-output-directory=$WORK"
+  "$WORK/$SRC_STEM.tex"
+)
+
+echo "[compile-demo] $ENGINE pass 1"
+"$ENGINE" "${ENGINE_ARGS[@]}" || true
+echo "[compile-demo] $ENGINE pass 2"
+"$ENGINE" "${ENGINE_ARGS[@]}" || true
+
+# Raw \cite path: run biber/bibtex if the generated .tex uses them.
+if grep -qE '\\(bibliography|addbibresource)\{' "$WORK/$SRC_STEM.tex"; then
+  if command -v biber >/dev/null 2>&1; then
+    echo "[compile-demo] biber"
+    (cd "$WORK" && biber "$SRC_STEM") || true
+  elif command -v bibtex >/dev/null 2>&1; then
+    echo "[compile-demo] bibtex"
+    (cd "$WORK" && bibtex "$SRC_STEM") || true
+  fi
+  echo "[compile-demo] $ENGINE pass 3 (post-bib)"
+  "$ENGINE" "${ENGINE_ARGS[@]}" || true
+fi
+
+if [[ ! -f "$WORK/$SRC_STEM.pdf" ]]; then
+  echo "[compile-demo] engine did not produce a PDF" >&2
+  tail -60 "$WORK/$SRC_STEM.log" 2>/dev/null | sed 's/^/    /' >&2 || true
+  exit 2
+fi
+
+OUT_PDF="$SRC_DIR/$SRC_STEM.pdf"
+cp "$WORK/$SRC_STEM.pdf" "$OUT_PDF"
+echo "[compile-demo] OK: $OUT_PDF"

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -29,6 +29,44 @@ export interface ToolchainStatus {
   texRootOwner?: string;
   /** The current process user, for comparison. */
   currentUser?: string;
+  /** Parsed SemVer-ish tuple for pandoc, e.g. [3, 9, 0]. */
+  pandocVersionParsed?: [number, number, number];
+  /** Parsed SemVer-ish tuple for pandoc-crossref. */
+  crossrefVersionParsed?: [number, number, number];
+  /** True when pandoc is old enough to be below the minimum floor. */
+  pandocBelowMinimum?: boolean;
+  /** True when pandoc-crossref is old enough to be below the minimum floor. */
+  crossrefBelowMinimum?: boolean;
+  /** When true, the file index was refreshed during checkToolchain and at least one package moved from missing to found. */
+  lsRRefreshed?: boolean;
+}
+
+/**
+ * Minimum versions Inkwell's compile pipeline has been tested against.
+ * Below these, compile may still work but specific features (smart
+ * typography, pandoc-crossref internal ref anchors, --citeproc output
+ * that matches the CSL block we extract) are not guaranteed to match
+ * what the extension expects.
+ */
+const PANDOC_MIN_VERSION: [number, number, number] = [3, 0, 0];
+const CROSSREF_MIN_VERSION: [number, number, number] = [0, 3, 0];
+
+function parseVersion(raw: string | undefined): [number, number, number] | undefined {
+  if (!raw) return undefined;
+  const m = raw.match(/(\d+)\.(\d+)(?:\.(\d+))?/);
+  if (!m) return undefined;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3] || "0", 10)];
+}
+
+function versionBelow(a: [number, number, number] | undefined, floor: [number, number, number]): boolean {
+  if (!a) return false; // unknown version: don't flag as old
+  if (a[0] !== floor[0]) return a[0] < floor[0];
+  if (a[1] !== floor[1]) return a[1] < floor[1];
+  return a[2] < floor[2];
+}
+
+function versionToString(v: [number, number, number]): string {
+  return `${v[0]}.${v[1]}.${v[2]}`;
 }
 
 let _extensionPath = "";
@@ -220,17 +258,38 @@ function buildTlmgrInstallCommand(
   return `${sudo}${tlmgr} install ${pkgList} && (${sudo}${texhash} || ${sudo}mktexlsr)`;
 }
 
-async function checkLatexPackages(kpsewhich: string | undefined): Promise<string[]> {
-  const requiredPackages = loadRequiredPackages();
-  if (!kpsewhich) return requiredPackages;
-
-  // Run texhash first to ensure the file database is current
-  const texhashDir = kpsewhich.replace(/\/kpsewhich$/, "/texhash");
-  if (fs.existsSync(texhashDir)) {
-    try {
-      await exec(texhashDir, [], { timeout: 30000 });
-    } catch {}
+async function runKpsewhichProbe(
+  kpsewhich: string,
+  requiredPackages: string[],
+  packageFiles: Record<string, string>,
+): Promise<string[]> {
+  const missing: string[] = [];
+  const batchSize = 20;
+  for (let i = 0; i < requiredPackages.length; i += batchSize) {
+    const batch = requiredPackages.slice(i, i + batchSize);
+    const results = await Promise.all(
+      batch.map(async (pkg) => {
+        const file = packageFiles[pkg] || `${pkg}.sty`;
+        try {
+          const { stdout } = await exec(kpsewhich, [file], { timeout: 5000 });
+          return stdout.trim() ? null : pkg;
+        } catch {
+          return pkg;
+        }
+      }),
+    );
+    for (const r of results) {
+      if (r) missing.push(r);
+    }
   }
+  return missing;
+}
+
+async function checkLatexPackages(
+  kpsewhich: string | undefined,
+): Promise<{ missing: string[]; refreshed: boolean }> {
+  const requiredPackages = loadRequiredPackages();
+  if (!kpsewhich) return { missing: requiredPackages, refreshed: false };
 
   // Packages whose primary installed file does not match the default
   // "<package>.sty" heuristic. Without these mappings, kpsewhich
@@ -260,26 +319,50 @@ async function checkLatexPackages(kpsewhich: string | undefined): Promise<string
     "fix2col": "fix2col.sty",
   };
 
-  const missing: string[] = [];
-  const batchSize = 20;
-  for (let i = 0; i < requiredPackages.length; i += batchSize) {
-    const batch = requiredPackages.slice(i, i + batchSize);
-    const results = await Promise.all(
-      batch.map(async (pkg) => {
-        const file = packageFiles[pkg] || `${pkg}.sty`;
-        try {
-          const { stdout } = await exec(kpsewhich, [file], { timeout: 5000 });
-          return stdout.trim() ? null : pkg;
-        } catch {
-          return pkg;
-        }
-      })
-    );
-    for (const r of results) {
-      if (r) missing.push(r);
-    }
+  // First probe — against whatever state the ls-R / file index happens
+  // to be in right now. If nothing is missing, skip the texhash pass.
+  const firstProbe = await runKpsewhichProbe(kpsewhich, requiredPackages, packageFiles);
+  if (firstProbe.length === 0) {
+    return { missing: [], refreshed: false };
   }
-  return missing;
+
+  // Stale ls-R recovery. tlmgr install silently fails to register new
+  // files in the file index when the tree is owned by a different
+  // user, or when the user never ran texhash after a manual
+  // package install. If any package shows as missing, run texhash
+  // once and re-probe; packages that transition from missing to
+  // found were only missing because the index was stale, not because
+  // they were actually absent. Most users never run texhash manually
+  // and get stuck in the "tlmgr install followed by compile still
+  // fails" loop.
+  const texhashPath = kpsewhich.replace(/\/kpsewhich$/, "/texhash");
+  const mktexlsrPath = kpsewhich.replace(/\/kpsewhich$/, "/mktexlsr");
+  const refreshTool = fs.existsSync(texhashPath)
+    ? texhashPath
+    : fs.existsSync(mktexlsrPath)
+    ? mktexlsrPath
+    : undefined;
+
+  if (!refreshTool) {
+    return { missing: firstProbe, refreshed: false };
+  }
+
+  let refreshSucceeded = false;
+  try {
+    await exec(refreshTool, [], { timeout: 30000 });
+    refreshSucceeded = true;
+  } catch {
+    // texhash can fail silently when the tree is not writable. The
+    // writeability check elsewhere will surface this.
+  }
+
+  if (!refreshSucceeded) {
+    return { missing: firstProbe, refreshed: false };
+  }
+
+  const secondProbe = await runKpsewhichProbe(kpsewhich, requiredPackages, packageFiles);
+  const rescuedCount = firstProbe.length - secondProbe.length;
+  return { missing: secondProbe, refreshed: rescuedCount > 0 };
 }
 
 /**
@@ -339,10 +422,13 @@ export async function checkToolchain(): Promise<ToolchainStatus> {
   ]);
 
   const kpsewhich = xelatex.installed ? await findKpsewhich() : undefined;
-  const missingPackages = xelatex.installed
+  const pkgResult = xelatex.installed
     ? await checkLatexPackages(kpsewhich)
-    : [];
+    : { missing: [], refreshed: false };
   const rootInfo = xelatex.installed ? await inspectTexRoot(kpsewhich) : {};
+
+  const pandocVersionParsed = parseVersion(pandoc.version);
+  const crossrefVersionParsed = parseVersion(crossref.version);
 
   return {
     pandoc,
@@ -351,7 +437,12 @@ export async function checkToolchain(): Promise<ToolchainStatus> {
     crossref,
     mmdc,
     texDistribution: detectDistribution(xelatex.path),
-    missingPackages,
+    missingPackages: pkgResult.missing,
+    lsRRefreshed: pkgResult.refreshed,
+    pandocVersionParsed,
+    crossrefVersionParsed,
+    pandocBelowMinimum: pandoc.installed && versionBelow(pandocVersionParsed, PANDOC_MIN_VERSION),
+    crossrefBelowMinimum: crossref.installed && versionBelow(crossrefVersionParsed, CROSSREF_MIN_VERSION),
     ...rootInfo,
   };
 }
@@ -369,7 +460,10 @@ export async function showToolchainStatus(): Promise<void> {
   const lines: string[] = [];
 
   if (status.pandoc.installed) {
-    lines.push(`Pandoc: ${status.pandoc.version || "installed"} (${status.pandoc.path})`);
+    const floorNote = status.pandocBelowMinimum
+      ? ` \u2014 below minimum ${versionToString(PANDOC_MIN_VERSION)}, upgrade recommended`
+      : "";
+    lines.push(`Pandoc: ${status.pandoc.version || "installed"} (${status.pandoc.path})${floorNote}`);
   } else {
     lines.push("Pandoc: not found");
   }
@@ -390,7 +484,10 @@ export async function showToolchainStatus(): Promise<void> {
   }
 
   if (status.crossref.installed) {
-    lines.push(`pandoc-crossref: ${status.crossref.version || "installed"} (${status.crossref.path})`);
+    const floorNote = status.crossrefBelowMinimum
+      ? ` \u2014 below minimum ${versionToString(CROSSREF_MIN_VERSION)}, upgrade recommended`
+      : "";
+    lines.push(`pandoc-crossref: ${status.crossref.version || "installed"} (${status.crossref.path})${floorNote}`);
   } else {
     lines.push("pandoc-crossref: not found (required for @fig:, @eq:, @tbl: cross-references)");
   }
@@ -404,7 +501,10 @@ export async function showToolchainStatus(): Promise<void> {
   const pkgCount = loadRequiredPackages().length;
   const missingCount = status.missingPackages.length;
   if (missingCount === 0 && status.xelatex.installed) {
-    lines.push(`LaTeX packages: all ${pkgCount} required packages found`);
+    const recoveryNote = status.lsRRefreshed
+      ? " (rescued after running texhash; file index was stale)"
+      : "";
+    lines.push(`LaTeX packages: all ${pkgCount} required packages found${recoveryNote}`);
   } else if (missingCount > 0) {
     lines.push(`LaTeX packages: ${missingCount} missing (${status.missingPackages.slice(0, 5).join(", ")}${missingCount > 5 ? ", ..." : ""})`);
   }
@@ -435,7 +535,10 @@ export async function showToolchainStatus(): Promise<void> {
     status.crossref.installed;
   const allGood = coreReady && missingCount === 0;
 
-  if (allGood && !ownershipBroken) {
+  const versionFloorBroken =
+    status.pandocBelowMinimum === true || status.crossrefBelowMinimum === true;
+
+  if (allGood && !ownershipBroken && !versionFloorBroken) {
     const mmdcNote = status.mmdc.installed
       ? ""
       : "\n(mmdc not found; mermaid diagrams will render as code in PDFs)";
@@ -467,6 +570,41 @@ export async function showToolchainStatus(): Promise<void> {
       return;
     }
     // "Ignore": fall through to other remediation options.
+  }
+
+  // Version-floor prompt.
+  if (versionFloorBroken) {
+    const stale: string[] = [];
+    if (status.pandocBelowMinimum) {
+      stale.push(
+        `pandoc ${status.pandoc.version || "(unknown)"} < ${versionToString(PANDOC_MIN_VERSION)}`,
+      );
+    }
+    if (status.crossrefBelowMinimum) {
+      stale.push(
+        `pandoc-crossref ${status.crossref.version || "(unknown)"} < ${versionToString(CROSSREF_MIN_VERSION)}`,
+      );
+    }
+    const buttons: string[] = [];
+    if (isMac) buttons.push("Upgrade with Homebrew");
+    buttons.push("Show instructions", "Ignore");
+    const choice = await vscode.window.showWarningMessage(
+      `Inkwell targets ${stale.join(", ")}. Older versions may work but are not tested against the extension's compile pipeline.`,
+      ...buttons,
+    );
+    if (choice === "Upgrade with Homebrew") {
+      const terminal = vscode.window.createTerminal("Inkwell: Upgrade pandoc");
+      terminal.show();
+      const upgrades: string[] = [];
+      if (status.pandocBelowMinimum) upgrades.push("pandoc");
+      if (status.crossrefBelowMinimum) upgrades.push("pandoc-crossref");
+      terminal.sendText(`brew upgrade ${upgrades.join(" ")} || brew install ${upgrades.join(" ")}`);
+      return;
+    } else if (choice === "Show instructions") {
+      showInstructions(status);
+      return;
+    }
+    // "Ignore" falls through.
   }
 
   // Core tools missing
@@ -512,10 +650,14 @@ export async function showToolchainStatus(): Promise<void> {
     const buttons: string[] = [];
     let message = `${missingCount} LaTeX package${missingCount > 1 ? "s" : ""} missing: ${status.missingPackages.join(", ")}`;
     if (isMac && !texAlreadyInstalled) {
-      message += '. Install Full MacTeX for the most reliable setup.';
+      message += ". Install Full MacTeX for the most reliable setup.";
       buttons.push("Install Full MacTeX (recommended)");
     }
-    buttons.push("Install packages with tlmgr", "Show details");
+    buttons.push(
+      "Install packages with tlmgr",
+      "Rebuild file index (texhash)",
+      "Show details",
+    );
 
     const choice = await vscode.window.showWarningMessage(message, ...buttons);
 
@@ -523,10 +665,27 @@ export async function showToolchainStatus(): Promise<void> {
       await installFullMacTeX(status);
     } else if (choice === "Install packages with tlmgr") {
       await installMissingPackages(status.missingPackages);
+    } else if (choice === "Rebuild file index (texhash)") {
+      await rebuildLsRIndex();
     } else if (choice === "Show details") {
       showPackageDetails(status);
     }
   }
+}
+
+async function rebuildLsRIndex(): Promise<void> {
+  const terminal = vscode.window.createTerminal("Inkwell: Rebuild file index");
+  terminal.show();
+  const texhash = await findTexhash();
+  if (!texhash) {
+    terminal.sendText('echo "texhash / mktexlsr not found on PATH. Install a TeX distribution first."');
+    return;
+  }
+  // Run without sudo first; if the tree is user-owned this works. If
+  // the tree is root-owned, ownership check will already have flagged
+  // it; still offer the sudo fallback on failure for users who declined
+  // the chown fix.
+  terminal.sendText(`${texhash} || sudo ${texhash}`);
 }
 
 async function installMissingPackages(packages: string[]): Promise<void> {

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -106,6 +106,11 @@ const FALLBACK_PACKAGES = [
   "supertabular", "matlab-prettifier", "lipsum", "hardwrap",
   "units", "silence",
   "pbalance", "extsizes", "fixtounicode",
+  // english.ldf is bundled with `babel` on full MacTeX but ships as
+  // a separate `babel-english` package on minimal TinyTeX, where
+  // `\usepackage[english]{babel}` otherwise fails with
+  // "Unknown option 'english'".
+  "babel-english",
   // Required by the rho / rmxaa templates even in English documents:
   // rhobabel.sty calls \iflanguage{spanish} which hard-errors when
   // the language is not declared to babel.
@@ -113,6 +118,8 @@ const FALLBACK_PACKAGES = [
   // Hit on minimal TinyTeX installs during the default pandoc
   // --template flow.
   "xstring", "fix2col",
+  // Required by adforn (rho ornamental glyphs).
+  "svn-prov",
   "amsfonts", "amscls", "tools", "preprint", "sttools",
   "graphics", "oberdiek", "psnfss",
   "mathpazo", "palatino", "bera", "soul", "stix2-type1", "tex-gyre",
@@ -311,12 +318,14 @@ async function checkLatexPackages(
     "oberdiek": "iflang.sty",
     "psnfss": "helvet.sty",
     "extsizes": "extarticle.cls",
+    "babel-english": "english.ldf",
     "babel-spanish": "spanish.ldf",
     // hyphen-spanish installs hyphenation patterns, not a .sty file.
     // kpsewhich resolves the format-file-embedded pattern through the
     // language.dat chain; the file that reliably shows up is loadhyph-es.tex.
     "hyphen-spanish": "loadhyph-es.tex",
     "fix2col": "fix2col.sty",
+    "svn-prov": "svn-prov.sty",
   };
 
   // First probe — against whatever state the ls-R / file index happens

--- a/templates/rmxaa/rmaa-rho-class/rhobabel.sty
+++ b/templates/rmxaa/rmaa-rho-class/rhobabel.sty
@@ -38,7 +38,14 @@
     \usepackage[spanish,es-nodecimaldot,es-noindentfirst]{babel}
 }
 {
-    \usepackage[english]{babel}
+    % Load spanish alongside english so the rhobabel translation
+    % hooks below (each wrapped in \iflanguage{spanish}{...}{...})
+    % find the language declared. \iflanguage is a hard error on a
+    % language that babel has not seen, which otherwise crashes every
+    % rmxaa compile on TinyTeX / BasicTeX where Spanish is not
+    % preloaded into the format file. english remains the primary
+    % language (last option in the list wins).
+    \usepackage[spanish,english]{babel}
 }
 
 %----------------------------------------------------------

--- a/templates/rmxaa/rmxaa.latex
+++ b/templates/rmxaa/rmxaa.latex
@@ -9,14 +9,6 @@
 
 \documentclass[$for(classoption)$$classoption$$sep$,$endfor$$if(classoption)$$else$9pt,twoside$endif$]{rmaa-rho-class/rmaa-rho}
 
-% Load spanish alongside english. rmaa-rho/rhobabel.sty contains
-% \iflanguage{spanish}{...}{...} branches that hard-error when the
-% language has not been declared to babel. On TinyTeX / BasicTeX this
-% otherwise crashes every rmxaa compile. See templates/rho/rho.latex
-% for the same fix applied to the rho template. english remains the
-% primary language (last option wins).
-\usepackage[spanish,english]{babel}
-
 % Pandoc citeproc manages the bibliography; suppress natbib's
 % author-year format check, which rejects citeproc's \bibitem entries.
 % The cls loads natbib[authoryear,numbers] and registers an


### PR DESCRIPTION
Completes items #5 and #7 from the reliability backlog filed against v0.2.3.

## Summary

- **Toolchain check: version floors.** Parse pandoc / pandoc-crossref versions and warn below tested minimums (pandoc >= 3.0.0, pandoc-crossref >= 0.3.0). One-click \`brew upgrade\` remediation.
- **Toolchain check: automatic ls-R refresh.** Two-pass package probe \u2014 if anything shows missing, run \`texhash\` and re-probe. Packages that transition to found were only missing because the index was stale. Surfaces the cause in the status line.
- **Toolchain check: one-click "Rebuild file index (texhash)"** in the package-install prompt.
- **CI: \`compile-demos\`** workflow. On every PR that touches a template, the requirements list, or the compile pipeline, boot Ubuntu + TinyTeX + tlmgr-install every required package, then compile each \`examples/demo-*.md\`. Uploads PDFs on success, \`.tex\` + \`.log\` on failure. Catches the v0.3.0 class of regressions (missing TinyTeX packages, unresolved cross-refs, babel-language crashes) before they ship.
- **\`scripts/compile-demo.sh\` + \`scripts/compile-all-demos.sh\`.** Standalone shell reimplementations of the extension's two-stage pipeline. Used by CI; also usable locally.
- **\`npm run test:installer\`** now also bash-syntax-checks the new scripts.

## Test plan

- [x] \`npm run verify\` (includes new bash-syntax check on the demo scripts).
- [x] \`npm run package\` \u2014 297.8 kb bundle.
- [ ] Reviewer: on a machine with pandoc < 3.0 installed, run **Inkwell: Check / Install Toolchain**. Expect the version-floor warning with the Homebrew upgrade button.
- [ ] Reviewer: the new workflow runs on this PR (touches templates/requirements/pipeline through the compile-demo script additions). It should pass end-to-end and attach the seven PDFs.

## Notes

- The compile-demos workflow job has a 20-minute timeout. Typical TinyTeX install + package pass + seven compiles is well under that.
- pandoc-crossref is installed from the upstream GitHub release because Ubuntu's apt does not ship it. If the release API is rate-limited, the step logs a warning and compile proceeds without crossref (so documents that do not use \`@fig:\` / \`@tbl:\` still succeed).