### PR TITLE
refactor: dedup shared logic + fix CRLF and binary-resolution inconsistencies

### DIFF
--- a/scripts/check-template-regressions.mjs
+++ b/scripts/check-template-regressions.mjs
@@ -32,6 +32,43 @@ for (const check of checks) {
   }
 }
 
+// The Pandoc extension list is necessarily duplicated across the TS/bash
+// boundary: src/compiler.ts (the real pipeline) and scripts/compile-demo.sh
+// (the CI compile harness). They must stay identical or CI compiles a
+// different document than the extension does. Guard against drift.
+{
+  const compilerSrc = fs.readFileSync(
+    path.join(repoRoot, "src", "compiler.ts"),
+    "utf8",
+  );
+  const arrayMatch = compilerSrc.match(
+    /const PANDOC_EXTENSIONS = \[([\s\S]*?)\]\.join\("\+"\)/,
+  );
+  const demoSrc = fs.readFileSync(
+    path.join(repoRoot, "scripts", "compile-demo.sh"),
+    "utf8",
+  );
+  const demoMatch = demoSrc.match(/PANDOC_EXTS="([^"]+)"/);
+
+  if (!arrayMatch || !demoMatch) {
+    failures += 1;
+    console.error(
+      "FAIL: could not locate PANDOC_EXTENSIONS (compiler.ts) or PANDOC_EXTS (compile-demo.sh)",
+    );
+  } else {
+    const tsExts = Array.from(arrayMatch[1].matchAll(/"([a-z_]+)"/g), (m) => m[1]);
+    const shExts = demoMatch[1].split("+").filter(Boolean);
+    if (tsExts.join("+") !== shExts.join("+")) {
+      failures += 1;
+      console.error(
+        "FAIL: PANDOC_EXTENSIONS drift between compiler.ts and compile-demo.sh",
+      );
+      console.error(`  compiler.ts:     ${tsExts.join("+")}`);
+      console.error(`  compile-demo.sh: ${shExts.join("+")}`);
+    }
+  }
+}
+
 if (failures > 0) {
   process.exit(1);
 }

--- a/scripts/compile-demo.sh
+++ b/scripts/compile-demo.sh
@@ -129,7 +129,9 @@ if [[ -d "$REPO_ROOT/.inkwell/references" ]]; then
   cp -R "$REPO_ROOT/.inkwell/references/." "$WORK/.inkwell/references/"
 fi
 
-# Pandoc extensions that the extension enables.
+# Pandoc extensions that the extension enables. Mirrored from
+# src/compiler.ts (PANDOC_EXTENSIONS); check-template-regressions.mjs fails
+# the build if the two drift.
 PANDOC_EXTS="raw_tex+raw_attribute+tex_math_dollars+citations+footnotes+yaml_metadata_block+implicit_figures+link_attributes+fenced_divs+bracketed_spans+pipe_tables+smart"
 
 CROSSREF_BIN=""

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -16,10 +16,12 @@ import { InkwellDiagnostics, CompileError } from "./diagnostics";
 import { getTemplateForDocument, copySupportingFiles, PdfEngine, ResolvedTemplate, collectAllFeatures } from "./templates";
 import { prepareForCompilation } from "./inject";
 import { writePreambleFile } from "./preamble";
-import { buildTexInvocationPath } from "./shell-env";
+import { buildTexInvocationPath, texBinSearchDirs } from "./shell-env";
 
 const exec = promisify(execFile);
 
+// Mirrored in scripts/compile-demo.sh (PANDOC_EXTS). check-template-regressions.mjs
+// fails the build if the two lists drift.
 const PANDOC_EXTENSIONS = [
   "raw_tex",
   "raw_attribute",
@@ -96,29 +98,19 @@ async function findBinary(name: string): Promise<string | undefined> {
   const cached = binaryCache.get(name);
   if (cached && Date.now() - cached.ts < BINARY_CACHE_TTL) return cached.result;
 
-  const common = [`/usr/local/bin/${name}`, `/usr/bin/${name}`];
-  const home = os.homedir();
-  const platformPaths = process.platform === "darwin"
-    ? [
-        `/opt/homebrew/bin/${name}`,
-        `/Library/TeX/texbin/${name}`,
-        `${home}/Library/TinyTeX/bin/universal-darwin/${name}`,
-        ...common,
-      ]
-    : [
-        ...common,
-        `${home}/.TinyTeX/bin/x86_64-linux/${name}`,
-        `${home}/.TinyTeX/bin/aarch64-linux/${name}`,
-      ];
-
-  for (const p of platformPaths) {
-    if (fs.existsSync(p)) {
-      binaryCache.set(name, { result: p, ts: Date.now() });
-      return p;
+  for (const dir of texBinSearchDirs()) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate)) {
+      binaryCache.set(name, { result: candidate, ts: Date.now() });
+      return candidate;
     }
   }
+  // Fall back to the OS resolver, but with the augmented TeX PATH so a
+  // GUI-launched editor (minimal launchd PATH) still resolves tools that
+  // the toolchain probe found. Without TEX_ENV here, "Check Toolchain"
+  // could report ready while compile fails with "binary not found".
   try {
-    const { stdout } = await exec("which", [name]);
+    const { stdout } = await exec("which", [name], { env: TEX_ENV });
     const trimmed = stdout.trim();
     if (trimmed) {
       binaryCache.set(name, { result: trimmed, ts: Date.now() });
@@ -128,6 +120,17 @@ async function findBinary(name: string): Promise<string | undefined> {
   return undefined;
 }
 
+// Compile serialization has three intentional layers, each at a distinct
+// entry point:
+//   1. This per-(document,output) lock coalesces identical concurrent
+//      compile() calls into one promise (e.g. preview button + onSave for
+//      the same file fire only one compile).
+//   2. extension.runCompile adds single-flight + latest-wins across the
+//      command / onSave / interval-timer triggers, so two *different*
+//      documents never compile concurrently.
+//   3. preview.handleCompile does the same for the webview compile button.
+// They are not redundant: the lock here only dedupes identical keys, while
+// the caller-side queues serialize distinct documents.
 const compileLocks = new Map<string, Promise<CompileResult>>();
 
 export function compile(
@@ -233,17 +236,22 @@ async function compileTeX(
       } catch (err: any) {
         if (err.stderr) stderr += "\n" + err.stderr;
       }
-      try {
-        const result = await exec(xelatex, args, {
-          cwd: sourceDir,
-          timeout: 120_000,
-          env: texEnv,
-        });
-        stdout = result.stdout;
-        stderr += "\n" + result.stderr;
-      } catch (err: any) {
-        if (err.stderr) stderr += "\n" + err.stderr;
-        if (err.stdout) stdout = err.stdout;
+      // Two passes after the bib tool: the first pulls in the .bbl, the
+      // second resolves the now-defined \cite labels and page references.
+      for (let pass = 0; pass < 2; pass++) {
+        try {
+          const result = await exec(xelatex, args, {
+            cwd: sourceDir,
+            timeout: 120_000,
+            env: texEnv,
+          });
+          stdout = result.stdout;
+          stderr += "\n" + result.stderr;
+        } catch (err: any) {
+          if (err.stderr) stderr += "\n" + err.stderr;
+          if (err.stdout) stdout = err.stdout;
+          if (pass === 0) continue;
+        }
       }
     }
   }
@@ -577,17 +585,22 @@ async function compilePandoc(
           } catch (err: any) {
             if (err.stderr) stderr += "\n" + err.stderr;
           }
-          try {
-            const r = await exec(engine, engineArgs, {
-              cwd: sourceDir,
-              timeout: 90_000,
-              env: texEnv,
-            });
-            stdout += r.stdout;
-            stderr += r.stderr;
-          } catch (err: any) {
-            if (err.stderr) stderr += err.stderr;
-            if (err.stdout) stdout += err.stdout;
+          // Two passes after the bib tool so the .bbl is pulled in and the
+          // resulting \cite / page references resolve in the same compile.
+          for (let pass = 0; pass < 2; pass++) {
+            try {
+              const r = await exec(engine, engineArgs, {
+                cwd: sourceDir,
+                timeout: 90_000,
+                env: texEnv,
+              });
+              stdout += r.stdout;
+              stderr += r.stderr;
+            } catch (err: any) {
+              if (err.stderr) stderr += err.stderr;
+              if (err.stdout) stdout += err.stdout;
+              if (pass === 0) continue;
+            }
           }
         }
       }

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,0 +1,55 @@
+// Shared YAML frontmatter primitives. Several modules previously each
+// re-implemented "find the --- ... --- block and pull a value out of the
+// inkwell: sub-mapping" with subtly different regexes. The variants
+// anchored on a literal "\n" silently failed on CRLF documents, so on
+// Windows the preview styling, code-block display mode, python-env, and
+// LaTeX preamble all no-opped. These helpers handle CRLF once, in one
+// place, by normalizing the captured frontmatter to LF (the body is left
+// byte-for-byte untouched).
+
+export interface SplitFrontmatter {
+  /** The YAML between the leading and trailing `---`, normalized to LF. */
+  fm: string;
+  /** Everything after the closing `---`, unmodified. */
+  body: string;
+}
+
+export function splitFrontmatter(text: string): SplitFrontmatter | undefined {
+  const match = text.match(
+    /^---\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/,
+  );
+  if (!match) return undefined;
+  return { fm: match[1].replace(/\r\n/g, "\n"), body: match[2] };
+}
+
+/** A top-level scalar value, e.g. `title: "..."`. Operates on LF frontmatter. */
+export function extractScalar(fm: string, key: string): string | undefined {
+  const m = fm.match(new RegExp(`^${key}:\\s*["']?(.+?)["']?\\s*$`, "m"));
+  return m ? m[1].trim() : undefined;
+}
+
+/**
+ * The indented block beneath a `key:` line with nothing after the colon
+ * (e.g. the `inkwell:` mapping). Returns the raw indented lines joined by
+ * LF, or undefined when the key is absent.
+ */
+export function extractIndentedBlock(fm: string, key: string): string | undefined {
+  const m = fm.match(new RegExp(`^${key}:\\s*$`, "m"));
+  if (!m) return undefined;
+  const start = m.index! + m[0].length;
+  const lines = fm.substring(start).split("\n");
+  const block: string[] = [];
+  for (const line of lines) {
+    if (/^\S/.test(line) && line.trim()) break;
+    block.push(line);
+  }
+  return block.join("\n");
+}
+
+/** An indented scalar inside a block returned by {@link extractIndentedBlock}. */
+export function extractIndentedValue(block: string, key: string): string | undefined {
+  const m = block.match(
+    new RegExp(`^\\s+${key}:\\s*["']?([^"'\\n]+?)["']?\\s*$`, "m"),
+  );
+  return m ? m[1].trim() : undefined;
+}

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -13,7 +13,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as crypto from "crypto";
 import { execFileSync } from "child_process";
-import { BlockResult, CodeBlock, DisplayMode, parseCodeBlocks, parseRunConfig, RunConfig } from "./runner";
+import { BlockResult, CodeBlock, DisplayMode, discoverArtifacts, parseCodeBlocks, parseQuotedAttrs, parseRunConfig, resolveVenvPython, RunConfig } from "./runner";
 import { buildCodeBlockPath, findBinaryViaShell } from "./shell-env";
 import { getInkwellOutputChannel } from "./inkwell-output";
 import {
@@ -350,16 +350,7 @@ export function gatherCachedResults(
       stdout = fs.readFileSync(path.join(blockDir, "stdout.txt"), "utf-8");
     } catch {}
 
-    const artifacts = new Map<string, string>();
-    try {
-      for (const entry of fs.readdirSync(blockDir)) {
-        if (entry === "stdout.txt" || entry === "stderr.txt" || entry.startsWith("block_")) continue;
-        if (fs.statSync(path.join(blockDir, entry)).isFile()) {
-          const name = path.basename(entry, path.extname(entry));
-          artifacts.set(name, path.join(blockDir, entry));
-        }
-      }
-    } catch {}
+    const artifacts = discoverArtifacts(blockDir);
 
     const cacheStatus: "hit" | "miss" =
       hasBlockDir && (stdout.trim().length > 0 || artifacts.size > 0) ? "hit" : "miss";
@@ -383,16 +374,9 @@ export function gatherCachedResults(
 const INLINE_EXPR_RE = /`\{python\}\s+([^`]+)`/g;
 
 function resolvePython(runConfig: RunConfig, docDir: string, projectRoot: string): string {
-  const envSpec = runConfig.pythonEnv;
-  if (envSpec) {
-    const home = process.env.HOME || "~";
-    for (const base of [projectRoot, docDir]) {
-      const resolved = path.resolve(base, envSpec.replace(/^~/, home));
-      for (const bin of ["bin/python3", "bin/python"]) {
-        const full = path.join(resolved, bin);
-        if (fs.existsSync(full)) return full;
-      }
-    }
+  if (runConfig.pythonEnv) {
+    const bin = resolveVenvPython(runConfig.pythonEnv, projectRoot, docDir);
+    if (bin) return bin;
   }
   return "python3";
 }
@@ -536,17 +520,6 @@ function mmdcAvailable(): boolean {
   return _mmdcAvailable;
 }
 
-function parseMermaidAttrs(raw: string | undefined): Record<string, string> {
-  if (!raw?.trim()) return {};
-  const attrs: Record<string, string> = {};
-  const re = /(\w+)="([^"]+)"/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(raw)) !== null) {
-    attrs[m[1]] = m[2];
-  }
-  return attrs;
-}
-
 /** `projectRoot` — Inkwell project directory containing `.inkwell/` (not the `.md` folder when nested). */
 export function renderMermaidBlocks(markdown: string, projectRoot: string): string {
   if (!mmdcAvailable()) return markdown;
@@ -566,7 +539,7 @@ export function renderMermaidBlocks(markdown: string, projectRoot: string): stri
   let offset = 0;
 
   for (const match of matches) {
-    const attrs = parseMermaidAttrs(match.attrsStr);
+    const attrs = parseQuotedAttrs(match.attrsStr || "");
     const hash = crypto
       .createHash("sha256")
       .update(match.source)

--- a/src/preamble.ts
+++ b/src/preamble.ts
@@ -6,6 +6,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { splitFrontmatter, extractIndentedBlock, extractIndentedValue } from "./frontmatter";
 
 export interface InkwellStyle {
   "code-bg"?: string;
@@ -22,73 +23,49 @@ export interface InkwellStyle {
 }
 
 export function parseInkwellStyle(text: string): InkwellStyle {
-  const match = text.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return {};
+  const fm = splitFrontmatter(text);
+  if (!fm) return {};
 
-  const yaml = match[1];
   const style: InkwellStyle = {};
 
-  const inkwellBlock = extractYamlBlock(yaml, "inkwell");
+  const inkwellBlock = extractIndentedBlock(fm.fm, "inkwell");
   if (!inkwellBlock) return style;
 
-  const codeBg = extractValue(inkwellBlock, "code-bg");
+  const codeBg = extractIndentedValue(inkwellBlock, "code-bg");
   if (codeBg) style["code-bg"] = codeBg;
 
-  const codeBorder = extractValue(inkwellBlock, "code-border");
+  const codeBorder = extractIndentedValue(inkwellBlock, "code-border");
   if (codeBorder === "true") style["code-border"] = true;
 
-  const codeFontSize = extractValue(inkwellBlock, "code-font-size");
+  const codeFontSize = extractIndentedValue(inkwellBlock, "code-font-size");
   if (codeFontSize) style["code-font-size"] = codeFontSize;
 
-  const codeRounded = extractValue(inkwellBlock, "code-rounded");
+  const codeRounded = extractIndentedValue(inkwellBlock, "code-rounded");
   if (codeRounded === "true") style["code-rounded"] = true;
 
-  const tables = extractValue(inkwellBlock, "tables");
+  const tables = extractIndentedValue(inkwellBlock, "tables");
   if (tables === "booktabs" || tables === "grid" || tables === "plain") {
     style.tables = tables;
   }
 
-  const tableFontSize = extractValue(inkwellBlock, "table-font-size");
+  const tableFontSize = extractIndentedValue(inkwellBlock, "table-font-size");
   if (tableFontSize) style["table-font-size"] = tableFontSize;
 
-  const tableStripe = extractValue(inkwellBlock, "table-stripe");
+  const tableStripe = extractIndentedValue(inkwellBlock, "table-stripe");
   if (tableStripe === "true") style["table-stripe"] = true;
 
-  const hangingIndent = extractValue(inkwellBlock, "hanging-indent");
+  const hangingIndent = extractIndentedValue(inkwellBlock, "hanging-indent");
   if (hangingIndent === "true") style["hanging-indent"] = true;
 
-  const columns = extractValue(inkwellBlock, "columns");
+  const columns = extractIndentedValue(inkwellBlock, "columns");
   if (columns) style.columns = parseInt(columns, 10) || undefined;
 
-  const captionStyle = extractValue(inkwellBlock, "caption-style");
+  const captionStyle = extractIndentedValue(inkwellBlock, "caption-style");
   if (captionStyle === "above" || captionStyle === "below") {
     style["caption-style"] = captionStyle;
   }
 
   return style;
-}
-
-function extractYamlBlock(yaml: string, key: string): string | undefined {
-  const pattern = new RegExp(`^${key}:\\s*$`, "m");
-  const match = yaml.match(pattern);
-  if (!match) return undefined;
-
-  const start = match.index! + match[0].length;
-  const lines = yaml.substring(start).split("\n");
-  const block: string[] = [];
-
-  for (const line of lines) {
-    if (line.match(/^\S/) && line.trim()) break;
-    block.push(line);
-  }
-
-  return block.join("\n");
-}
-
-function extractValue(block: string, key: string): string | undefined {
-  const pattern = new RegExp(`^\\s+${key}:\\s*["']?([^"'\\n]+?)["']?\\s*$`, "m");
-  const match = block.match(pattern);
-  return match ? match[1].trim() : undefined;
 }
 
 function parseHexColor(hex: string): { r: number; g: number; b: number } | undefined {
@@ -109,6 +86,8 @@ function parseHexColor(hex: string): { r: number; g: number; b: number } | undef
   }
   return undefined;
 }
+
+const VALID_LATEX_FONT_SIZES = ["tiny", "scriptsize", "footnotesize", "small", "normalsize"];
 
 const NAMED_COLORS: Record<string, string> = {
   "light-gray": "245,245,245",
@@ -146,7 +125,7 @@ export function generatePreamble(style: InkwellStyle): string {
       lines.push("\\usepackage{mdframed}");
       lines.push("\\renewenvironment{Shaded}{%");
       lines.push("  \\begin{mdframed}[backgroundcolor=inkwell-shade," +
-        "linewidth=" + (style["code-border"] ? "0.4pt" : "0pt") + "," +
+        "linewidth=0.4pt," +
         "linecolor=black!20," +
         "innerleftmargin=8pt,innerrightmargin=8pt," +
         "innertopmargin=6pt,innerbottommargin=6pt," +
@@ -155,8 +134,7 @@ export function generatePreamble(style: InkwellStyle): string {
 
     if (style["code-font-size"]) {
       const size = style["code-font-size"];
-      const valid = ["tiny", "scriptsize", "footnotesize", "small", "normalsize"];
-      if (valid.includes(size)) {
+      if (VALID_LATEX_FONT_SIZES.includes(size)) {
         lines.push(`\\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\\\\{\\},fontsize=\\${size}}`);
       }
     }
@@ -174,8 +152,7 @@ export function generatePreamble(style: InkwellStyle): string {
 
     if (style["table-font-size"]) {
       const size = style["table-font-size"];
-      const valid = ["tiny", "scriptsize", "footnotesize", "small", "normalsize"];
-      if (valid.includes(size)) {
+      if (VALID_LATEX_FONT_SIZES.includes(size)) {
         lines.push(`\\AtBeginEnvironment{longtable}{\\${size}}`);
         lines.push(`\\AtBeginEnvironment{tabular}{\\${size}}`);
         lines.push("\\usepackage{etoolbox}");

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -15,6 +15,7 @@ import { prepareForPreview } from "./inject";
 import { getInkwellOutputChannel } from "./inkwell-output";
 import { getInkwellOutputsDir, getInkwellProjectRoot } from "./config";
 import { renderCitations, CitationRenderResult } from "./citations";
+import { splitFrontmatter, extractIndentedBlock, extractIndentedValue } from "./frontmatter";
 
 const md = new MarkdownIt({
   html: true,
@@ -1662,11 +1663,11 @@ interface FrontmatterResult {
 type SectionNumberingStyle = "decimal" | "legal" | "none";
 
 function stripFrontmatter(text: string): FrontmatterResult {
-  const match = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  if (!match) return { body: text };
+  const split = splitFrontmatter(text);
+  if (!split) return { body: text };
 
-  const fm = match[1];
-  const body = match[2];
+  const fm = split.fm;
+  const body = split.body;
 
   const scalar = (key: string): string | undefined => {
     const m = fm.match(new RegExp(`^${key}:\\s*['"]?(.+?)['"]?\\s*$`, "m"));
@@ -1691,54 +1692,54 @@ function stripFrontmatter(text: string): FrontmatterResult {
       .filter(Boolean);
   };
 
-  const inkwellBlock = extractInkwellBlock(fm);
+  const inkwellBlock = extractIndentedBlock(fm, "inkwell");
   const tableStyleRaw = inkwellBlock
-    ? inkwellValue(inkwellBlock, "tables")
+    ? extractIndentedValue(inkwellBlock, "tables")
     : undefined;
   const tableStyle =
     tableStyleRaw === "booktabs" || tableStyleRaw === "grid" || tableStyleRaw === "plain"
       ? tableStyleRaw
       : undefined;
   const captionStyleRaw = inkwellBlock
-    ? inkwellValue(inkwellBlock, "caption-style")
+    ? extractIndentedValue(inkwellBlock, "caption-style")
     : undefined;
   const captionStyle =
     captionStyleRaw === "above" || captionStyleRaw === "below"
       ? captionStyleRaw
       : undefined;
   const tableStripe = inkwellBlock
-    ? inkwellValue(inkwellBlock, "table-stripe") === "true"
+    ? extractIndentedValue(inkwellBlock, "table-stripe") === "true"
     : false;
   const tableFontSize = inkwellBlock
-    ? inkwellValue(inkwellBlock, "table-font-size")
+    ? extractIndentedValue(inkwellBlock, "table-font-size")
     : undefined;
   const mermaidMaxWidth = inkwellBlock
-    ? inkwellValue(inkwellBlock, "mermaid-max-width")
+    ? extractIndentedValue(inkwellBlock, "mermaid-max-width")
     : undefined;
   const mermaidMaxHeight = inkwellBlock
-    ? inkwellValue(inkwellBlock, "mermaid-max-height")
+    ? extractIndentedValue(inkwellBlock, "mermaid-max-height")
     : undefined;
   const headingFont = inkwellBlock
-    ? inkwellValue(inkwellBlock, "heading-font")
+    ? extractIndentedValue(inkwellBlock, "heading-font")
     : undefined;
   const headingColor = inkwellBlock
-    ? inkwellValue(inkwellBlock, "heading-color")
+    ? extractIndentedValue(inkwellBlock, "heading-color")
     : undefined;
   const headingWeight = inkwellBlock
-    ? inkwellValue(inkwellBlock, "heading-weight")
+    ? extractIndentedValue(inkwellBlock, "heading-weight")
     : undefined;
   const headingScaleRaw = inkwellBlock
-    ? inkwellValue(inkwellBlock, "heading-scale")
+    ? extractIndentedValue(inkwellBlock, "heading-scale")
     : undefined;
   const headingScale = headingScaleRaw ? parseFloat(headingScaleRaw) : undefined;
   const codeFontSize = inkwellBlock
-    ? inkwellValue(inkwellBlock, "code-font-size")
+    ? extractIndentedValue(inkwellBlock, "code-font-size")
     : undefined;
   const captionFontSize = inkwellBlock
-    ? inkwellValue(inkwellBlock, "caption-font-size")
+    ? extractIndentedValue(inkwellBlock, "caption-font-size")
     : undefined;
   const sectionNumberingRaw = inkwellBlock
-    ? inkwellValue(inkwellBlock, "section-numbering")
+    ? extractIndentedValue(inkwellBlock, "section-numbering")
     : undefined;
   const sectionNumbering: SectionNumberingStyle =
     sectionNumberingRaw === "legal" || sectionNumberingRaw === "outline"
@@ -1787,26 +1788,6 @@ function stripFrontmatter(text: string): FrontmatterResult {
     csl: scalar("csl"),
     linkCitations,
   };
-}
-
-function extractInkwellBlock(fm: string): string | undefined {
-  const m = fm.match(/^inkwell:\s*$/m);
-  if (!m) return undefined;
-  const start = m.index! + m[0].length;
-  const lines = fm.substring(start).split("\n");
-  const block: string[] = [];
-  for (const line of lines) {
-    if (line.match(/^\S/) && line.trim()) break;
-    block.push(line);
-  }
-  return block.join("\n");
-}
-
-function inkwellValue(block: string, key: string): string | undefined {
-  const m = block.match(
-    new RegExp(`^\\s+${key}:\\s*["']?([^"'\\n]+?)["']?\\s*$`, "m"),
-  );
-  return m ? m[1].trim() : undefined;
 }
 
 function addDataLineAttrs(html: string): string {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -9,6 +9,7 @@ import * as fs from "fs";
 import { execFile, ChildProcess } from "child_process";
 import { getBlockHash, loadCache, saveCache } from "./cache";
 import { getInkwellOutputsDir, getInkwellProjectRoot, resolveBlockFilePath } from "./config";
+import { splitFrontmatter, extractIndentedBlock, extractIndentedValue } from "./frontmatter";
 
 export class RunCancellation {
   private _cancelled = false;
@@ -102,29 +103,24 @@ const BLOCK_PATTERN = /^```\{(\w+)([^}]*)\}\s*\n([\s\S]*?)^```/gm;
 
 export function parseRunConfig(markdown: string): RunConfig {
   const config: RunConfig = {};
-  const fmMatch = markdown.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) return config;
+  const fm = splitFrontmatter(markdown);
+  if (!fm) return config;
 
-  const fm = fmMatch[1];
-  const inkwellBlock = fm.match(/^inkwell:\s*\n((?:[ \t]+.*\n?)*)/m);
-  if (!inkwellBlock) return config;
+  const block = extractIndentedBlock(fm.fm, "inkwell");
+  if (!block) return config;
 
-  const block = inkwellBlock[1] || "";
-  const pyMatch = block.match(/^\s+python-env:\s*["']?(.+?)["']?\s*$/m);
-  if (pyMatch) config.pythonEnv = pyMatch[1].trim();
+  const pyEnv = extractIndentedValue(block, "python-env");
+  if (pyEnv) config.pythonEnv = pyEnv;
 
-  const rMatch = block.match(/^\s+r-env:\s*["']?(.+?)["']?\s*$/m);
-  if (rMatch) config.rEnv = rMatch[1].trim();
+  const rEnv = extractIndentedValue(block, "r-env");
+  if (rEnv) config.rEnv = rEnv;
 
-  const nodeMatch = block.match(/^\s+node-env:\s*["']?(.+?)["']?\s*$/m);
-  if (nodeMatch) config.nodeEnv = nodeMatch[1].trim();
+  const nodeEnv = extractIndentedValue(block, "node-env");
+  if (nodeEnv) config.nodeEnv = nodeEnv;
 
-  const displayMatch = block.match(/^\s+code-display:\s*["']?(\w+)["']?\s*$/m);
-  if (displayMatch) {
-    const val = displayMatch[1].trim() as DisplayMode;
-    if (["output", "both", "code", "none"].includes(val)) {
-      config.defaultDisplay = val;
-    }
+  const display = extractIndentedValue(block, "code-display");
+  if (display && ["output", "both", "code", "none"].includes(display)) {
+    config.defaultDisplay = display as DisplayMode;
   }
 
   return config;
@@ -147,7 +143,7 @@ export function parseCodeBlocks(markdown: string): CodeBlock[] {
     const startLine = markdown.substring(0, charOffset).split("\n").length;
     const endLine = startLine + raw.split("\n").length - 1;
 
-    const attrs = parseAttrs(attrsStr);
+    const attrs = parseQuotedAttrs(attrsStr);
 
     const display = (attrs.display as DisplayMode) || undefined;
     const noCache = attrs.cache === "false" || attrs.cache === "no";
@@ -172,7 +168,8 @@ export function parseCodeBlocks(markdown: string): CodeBlock[] {
   return blocks;
 }
 
-function parseAttrs(str: string): Record<string, string> {
+/** Parse `key="value"` attribute pairs from a fenced-block info string. */
+export function parseQuotedAttrs(str: string): Record<string, string> {
   const attrs: Record<string, string> = {};
   const pattern = /(\w+)="([^"]+)"/g;
   let m: RegExpExecArray | null;
@@ -180,6 +177,28 @@ function parseAttrs(str: string): Record<string, string> {
     attrs[m[1]] = m[2];
   }
   return attrs;
+}
+
+/** The python binary inside a venv directory, preferring python3. */
+export function venvPythonBin(venvDir: string): string | undefined {
+  const p3 = path.join(venvDir, "bin", "python3");
+  const p = path.join(venvDir, "bin", "python");
+  return fs.existsSync(p3) ? p3 : fs.existsSync(p) ? p : undefined;
+}
+
+/** Resolve a `python-env` spec (relative to project root or document dir) to its python binary. */
+export function resolveVenvPython(
+  envSpec: string,
+  projectRoot: string,
+  docDir: string,
+): string | undefined {
+  const home = process.env.HOME || "~";
+  const spec = envSpec.replace(/^~/, home);
+  for (const base of [projectRoot, docDir]) {
+    const bin = venvPythonBin(path.resolve(base, spec));
+    if (bin) return bin;
+  }
+  return undefined;
 }
 
 export interface ResolvedInterpreter {
@@ -231,9 +250,7 @@ function resolveInterpreter(
     const isNode = langKey === "node" || langKey === "javascript";
 
     if (isPython) {
-      const bin = path.join(resolved, "bin", "python3");
-      const binAlt = path.join(resolved, "bin", "python");
-      const interpreter = fs.existsSync(bin) ? bin : fs.existsSync(binAlt) ? binAlt : undefined;
+      const interpreter = venvPythonBin(resolved);
       if (!interpreter) {
         return {
           cmd: defaultCmd, args: defaultArgs, envVars: {},
@@ -407,7 +424,7 @@ export async function runBlock(
   };
 }
 
-function discoverArtifacts(outputDir: string): Map<string, string> {
+export function discoverArtifacts(outputDir: string): Map<string, string> {
   const artifacts = new Map<string, string>();
   const skip = new Set(["stdout.txt", "stderr.txt"]);
 

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -36,6 +36,9 @@ inkwell:
 
 `;
 
+const DEFAULT_REQUIREMENTS =
+  "numpy\nmatplotlib\npandas\npolars\nscikit-learn\numap-learn\nseaborn\n";
+
 const GITIGNORE = `.inkwell/outputs/
 .inkwell/compiled/
 .inkwell/mermaid/
@@ -493,7 +496,7 @@ export async function setupWorkspace(): Promise<void> {
   if (envChoice?.label === "Yes") {
     const reqPath = path.join(baseDir, "requirements.txt");
     if (!fs.existsSync(reqPath)) {
-      fs.writeFileSync(reqPath, "numpy\nmatplotlib\npandas\npolars\nscikit-learn\numap-learn\nseaborn\n");
+      fs.writeFileSync(reqPath, DEFAULT_REQUIREMENTS);
       report.push("created requirements.txt");
     }
     const terminal = vscode.window.createTerminal("Inkwell Setup");
@@ -581,7 +584,7 @@ Write your content here. Cite sources with [@knuth1984] and use inline math like
   if (opts.pythonEnv) {
     const reqPath = path.join(opts.dir, "requirements.txt");
     if (!fs.existsSync(reqPath)) {
-      fs.writeFileSync(reqPath, "numpy\nmatplotlib\npandas\npolars\nscikit-learn\numap-learn\nseaborn\n");
+      fs.writeFileSync(reqPath, DEFAULT_REQUIREMENTS);
     }
   }
 
@@ -729,4 +732,3 @@ function ensureStarterFiles(projectRoot: string): string[] {
   }
   return created;
 }
-

--- a/src/shell-env.ts
+++ b/src/shell-env.ts
@@ -116,6 +116,81 @@ export function buildCodeBlockPath(): string {
   ]);
 }
 
+/**
+ * Ordered directories to search when locating a TeX/Pandoc/Node binary by
+ * absolute path. This is the single source of truth shared by the toolchain
+ * probe and the compile pipeline's binary resolver, so the "Check Toolchain"
+ * report and the actual compile can never disagree about where a tool lives.
+ * Discovery order prefers Homebrew, then user-local Node/TeX, then system and
+ * TeX Live trees.
+ */
+export function texBinSearchDirs(): string[] {
+  const home = os.homedir();
+  const npmGlobal = path.join(home, ".npm-global", "bin");
+  const nodeTools = collectNodeToolBinDirs();
+  const common = ["/usr/local/bin", "/usr/bin"];
+
+  if (process.platform === "darwin") {
+    return [
+      "/opt/homebrew/bin",
+      npmGlobal,
+      ...nodeTools,
+      ...common,
+      "/Library/TeX/texbin",
+      path.join(home, "Library/TinyTeX/bin/universal-darwin"),
+    ];
+  }
+
+  return [
+    npmGlobal,
+    ...nodeTools,
+    ...common,
+    path.join(home, "bin"),
+    `${home}/.TinyTeX/bin/x86_64-linux`,
+    `${home}/.TinyTeX/bin/aarch64-linux`,
+    "/usr/local/texlive/2024/bin/x86_64-linux",
+    "/usr/local/texlive/2025/bin/x86_64-linux",
+    "/usr/local/texlive/2026/bin/x86_64-linux",
+  ];
+}
+
+/**
+ * Resolve an executable to an absolute path: check {@link texBinSearchDirs}
+ * first, then fall back to the OS resolver (`which`/`where`) run with the
+ * augmented TeX PATH so GUI-launched editors (which inherit a minimal PATH
+ * from launchd) still find tools installed in a developer shell.
+ */
+export function findExecutableSync(name: string): string | undefined {
+  for (const dir of texBinSearchDirs()) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  try {
+    const env = { ...process.env, PATH: buildTexInvocationPath() };
+    if (process.platform === "win32") {
+      const comspec = process.env.ComSpec || "cmd.exe";
+      const out = execFileSync(comspec, ["/d", "/s", "/c", `where ${name}`], {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: "pipe",
+        env,
+      });
+      const line = out.trim().split(/\r?\n/)[0]?.trim();
+      return line && fs.existsSync(line) ? line : undefined;
+    }
+    const out = execFileSync("which", [name], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: "pipe",
+      env,
+    });
+    const resolved = out.trim().split(/\r?\n/)[0]?.trim();
+    return resolved && fs.existsSync(resolved) ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** PATH for Pandoc / XeLaTeX / pdfLaTeX runs (TeX-heavy order, plus Node shims). */
 export function buildTexInvocationPath(): string {
   const base = ["/usr/local/bin", "/usr/bin"];

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { findInkwellRoot } from "./config";
+import { splitFrontmatter } from "./frontmatter";
 
 export type PdfEngine = "xelatex" | "pdflatex" | "lualatex";
 
@@ -203,7 +204,15 @@ export function resolveTemplate(
   return all.get(templateId);
 }
 
-const outputChannel = vscode.window.createOutputChannel("Inkwell Templates");
+// Lazily created so merely importing this module (e.g. from the compiler)
+// does not register an output channel before the extension is even active.
+let _outputChannel: vscode.OutputChannel | undefined;
+function outputChannel(): vscode.OutputChannel {
+  if (!_outputChannel) {
+    _outputChannel = vscode.window.createOutputChannel("Inkwell Templates");
+  }
+  return _outputChannel;
+}
 
 // Resolution order: frontmatter template field > manifest.json > built-in default.
 // This lets per-document overrides coexist with a project-level default.
@@ -216,12 +225,12 @@ export function getTemplateForDocument(
   if (fmTemplate) {
     const resolved = resolveTemplate(fmTemplate, document.uri);
     if (resolved) {
-      outputChannel.appendLine(
+      outputChannel().appendLine(
         `[template] ${path.basename(document.fileName)}: using frontmatter template "${fmTemplate}"`
       );
       return resolved;
     }
-    outputChannel.appendLine(
+    outputChannel().appendLine(
       `[template] ${path.basename(document.fileName)}: frontmatter says "${fmTemplate}" but template not found, falling through`
     );
   }
@@ -235,7 +244,7 @@ export function getTemplateForDocument(
       if (manifest.template) {
         const resolved = resolveTemplate(manifest.template, document.uri);
         if (resolved) {
-          outputChannel.appendLine(
+          outputChannel().appendLine(
             `[template] ${path.basename(document.fileName)}: using manifest template "${manifest.template}" (${manifestPath})`
           );
           return resolved;
@@ -244,7 +253,7 @@ export function getTemplateForDocument(
     } catch {}
   }
 
-  outputChannel.appendLine(
+  outputChannel().appendLine(
     `[template] ${path.basename(document.fileName)}: using built-in default`
   );
   const fallback = resolveTemplate("inkwell", document.uri);
@@ -257,9 +266,11 @@ export function getTemplateForDocument(
 }
 
 function extractFrontmatterTemplate(text: string): string | undefined {
-  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!match) return undefined;
-  const templateMatch = match[1].match(/^template:\s*['"]?([^#'"}\r\n]+?)['"]?\s*$/m);
+  const fm = splitFrontmatter(text);
+  if (!fm) return undefined;
+  // Keep the comment-stripping value pattern: a bare `template: foo  # note`
+  // should resolve to `foo`, which a generic scalar parser would not strip.
+  const templateMatch = fm.fm.match(/^template:\s*['"]?([^#'"}\n]+?)['"]?\s*$/m);
   return templateMatch ? templateMatch[1].trim() : undefined;
 }
 

--- a/src/toolchain.ts
+++ b/src/toolchain.ts
@@ -9,7 +9,7 @@ import { promisify } from "util";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { collectNodeToolBinDirs, findBinaryViaShell } from "./shell-env";
+import { buildTexInvocationPath, findBinaryViaShell, texBinSearchDirs } from "./shell-env";
 
 const exec = promisify(execFile);
 
@@ -129,33 +129,14 @@ const FALLBACK_PACKAGES = [
 const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
 
-function searchPaths(): string[] {
-  const home = os.homedir();
-  const npmGlobal = path.join(home, ".npm-global", "bin");
-  const nodeBins = collectNodeToolBinDirs();
-  const common = ["/usr/local/bin", "/usr/bin"];
-  if (isMac) {
-    return [
-      "/opt/homebrew/bin",
-      npmGlobal,
-      ...nodeBins,
-      ...common,
-      "/Library/TeX/texbin",
-      path.join(home, "Library/TinyTeX/bin/universal-darwin"),
-    ];
-  }
-  return [
-    npmGlobal,
-    ...nodeBins,
-    ...common,
-    `${home}/bin`,
-    `${home}/.TinyTeX/bin/x86_64-linux`,
-    `${home}/.TinyTeX/bin/aarch64-linux`,
-    "/usr/local/texlive/2024/bin/x86_64-linux",
-    "/usr/local/texlive/2025/bin/x86_64-linux",
-    "/usr/local/texlive/2026/bin/x86_64-linux",
-  ];
-}
+// Shared with the compile pipeline so the toolchain report and the actual
+// compile resolve binaries from the same set of directories.
+const searchPaths = texBinSearchDirs;
+
+// Augmented PATH for `which` fallbacks: a GUI-launched editor inherits a
+// minimal PATH from launchd, so a bare `which` would miss tools that live
+// in a developer shell's PATH.
+const WHICH_ENV = { ...process.env, PATH: buildTexInvocationPath() };
 
 async function probe(
   name: string
@@ -175,7 +156,7 @@ async function probe(
     }
   }
   try {
-    const { stdout: whichOut } = await exec("which", [name]);
+    const { stdout: whichOut } = await exec("which", [name], { env: WHICH_ENV });
     const p = whichOut.trim();
     if (p) {
       try {
@@ -230,7 +211,7 @@ async function findKpsewhich(): Promise<string | undefined> {
     if (fs.existsSync(candidate)) return candidate;
   }
   try {
-    const { stdout } = await exec("which", ["kpsewhich"]);
+    const { stdout } = await exec("which", ["kpsewhich"], { env: WHICH_ENV });
     const p = stdout.trim();
     if (p) return p;
   } catch {}
@@ -243,7 +224,7 @@ async function findBinary(name: string): Promise<string | undefined> {
     if (fs.existsSync(candidate)) return candidate;
   }
   try {
-    const { stdout } = await exec("which", [name]);
+    const { stdout } = await exec("which", [name], { env: WHICH_ENV });
     const p = stdout.trim();
     if (p) return p;
   } catch {}


### PR DESCRIPTION
## Summary

A systematic code review with incremental testing. Consolidates duplicated logic into shared helpers and fixes two correctness inconsistencies the duplication was hiding. Behavior-preserving except for the two bug fixes and an extra post-bibliography engine pass.

**Correctness**
- **Binary resolution unified.** New `shell-env.texBinSearchDirs()` / `findExecutableSync()` is the single source of truth; `compiler.findBinary` and `toolchain` both use it, and every `which` fallback runs with the augmented TeX PATH. Previously the compile pipeline used a narrower list + bare `which`, so "Check Toolchain" could report ready while compile failed to find a tool (GUI-launched editors, Linux TeX Live).
- **CRLF frontmatter.** New CRLF-aware `src/frontmatter.ts` feeds `preamble`, `runner`, `templates`, and `preview`. Previously CRLF documents silently lost inkwell style, `code-display`, `python-env`, and variable collection.

**De-duplication**
- One frontmatter parser instead of five ad-hoc ones.
- One binary/dir resolver instead of three.
- Shared `parseQuotedAttrs` + `discoverArtifacts` (`runner` → `inject`).
- Shared `venvPythonBin` / `resolveVenvPython`.
- `PANDOC_EXTENSIONS` now drift-guarded across `compiler.ts` and `compile-demo.sh`.

**Cleanup**
- Removed a dead `code-border` ternary and a duplicate font-size whitelist (`preamble.ts`).
- Single `DEFAULT_REQUIREMENTS` (`scaffold.ts`).
- Lazy output channel (no import-time side effect) in `templates.ts`.
- Second engine pass after biber/bibtex so references resolve on first compile.
- Documented the (intentional, non-redundant) three-layer compile serialization.

Closes #86

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:regressions` (incl. new PANDOC_EXTENSIONS drift guard)
- [x] `npm run test:stability`
- [x] `npm run test:installer`
- [x] `npm run package` (esbuild bundle builds)
- [x] CRLF vs LF frontmatter parity verified with a focused test
- [x] `findExecutableSync` resolves pandoc / xelatex / pdflatex / pandoc-crossref / biber
- [x] All 6 template demos that don't require a runtime-generated asset compile end-to-end (default, eth-report, ludus, rho, rmxaa, tmsce)

### Note
`demo-tufte` is unaffected by this PR: it generates `.inkwell/figures/anscombe.pdf` from a Python block at runtime, which the compile-only CI harness never executes. Aligning `compile-demo.sh` to copy `.inkwell/figures` (the extension's `copySiblingFiles` already does) is a separate follow-up.