### PR TITLE
docs(references): expand bibliography

### DIFF
--- a/.inkwell/references/refs.bib
+++ b/.inkwell/references/refs.bib
@@ -37,26 +37,143 @@
   doi     = {10.1109/MCSE.2007.55}
 }
 
-@book{fourier1822,
-  author    = {Fourier, Joseph},
-  title     = {Th\'{e}orie analytique de la chaleur},
-  year      = {1822},
-  publisher = {Firmin Didot},
-  address   = {Paris}
+@techreport{sweeney2000,
+  author      = {Sweeney, Latanya},
+  title       = {Simple Demographics Often Identify People Uniquely},
+  institution = {Carnegie Mellon University},
+  type        = {Data Privacy Working Paper},
+  number      = {3},
+  year        = {2000},
+  address     = {Pittsburgh, PA},
+  url         = {https://dataprivacylab.org/projects/identifiability/paper1.pdf}
 }
 
-@book{euler1748,
-  author    = {Euler, Leonhard},
-  title     = {Introductio in analysin infinitorum},
-  year      = {1748},
-  publisher = {Bousquet},
-  address   = {Lausanne}
+@article{elemam2011,
+  author  = {El Emam, Khaled and Jonker, Elizabeth and Arbuckle, Luk and Malin, Bradley},
+  title   = {A Systematic Review of Re-Identification Attacks on Health Data},
+  journal = {PLoS ONE},
+  volume  = {6},
+  number  = {12},
+  pages   = {e28071},
+  year    = {2011},
+  doi     = {10.1371/journal.pone.0028071}
 }
 
-@book{lamport1994,
-  author    = {Lamport, Leslie},
-  title     = {{\LaTeX}: A Document Preparation System},
-  edition   = {2nd},
-  publisher = {Addison-Wesley},
-  year      = {1994}
+@book{elemam2013,
+  author    = {El Emam, Khaled},
+  title     = {Guide to the De-Identification of Personal Health Information},
+  publisher = {CRC Press},
+  year      = {2013},
+  doi       = {10.1201/b14764}
+}
+
+@techreport{hhs2012,
+  author      = {{U.S. Department of Health and Human Services}},
+  title       = {Guidance Regarding Methods for De-identification of Protected Health Information in Accordance with the {Health Insurance Portability and Accountability Act (HIPAA)} Privacy Rule},
+  institution = {U.S. Department of Health and Human Services},
+  year        = {2012},
+  note        = {Last reviewed February 3, 2025},
+  address     = {Washington, DC},
+  url         = {https://www.hhs.gov/hipaa/for-professionals/special-topics/de-identification/index.html}
+}
+
+@article{samarati2001,
+  author  = {Samarati, Pierangela},
+  title   = {Protecting Respondents' Identities in Microdata Release},
+  journal = {IEEE Transactions on Knowledge and Data Engineering},
+  volume  = {13},
+  number  = {6},
+  pages   = {1010--1027},
+  year    = {2001},
+  doi     = {10.1109/69.971193}
+}
+
+@article{malin2011,
+  author  = {Malin, Bradley and Benitez, Kathleen and Masys, Daniel},
+  title   = {Never Too Old for Anonymity: A Statistical Standard for Demographic Data Sharing via the {HIPAA} Privacy Rule},
+  journal = {Journal of the American Medical Informatics Association},
+  volume  = {18},
+  number  = {1},
+  pages   = {3--10},
+  year    = {2011},
+  doi     = {10.1136/jamia.2010.004622}
+}
+
+@article{machanavajjhala2007,
+  author  = {Machanavajjhala, Ashwin and Kifer, Daniel and Gehrke, Johannes and Venkitasubramaniam, Muthuramakrishnan},
+  title   = {l-Diversity: Privacy Beyond k-Anonymity},
+  journal = {ACM Transactions on Knowledge Discovery from Data},
+  volume  = {1},
+  number  = {1},
+  pages   = {Article 3},
+  year    = {2007},
+  doi     = {10.1145/1217299.1217302}
+}
+
+@techreport{nist2015fips180,
+  author      = {{National Institute of Standards and Technology}},
+  title       = {Secure Hash Standard ({SHS})},
+  number      = {FIPS PUB 180-4},
+  institution = {National Institute of Standards and Technology},
+  year        = {2015},
+  doi         = {10.6028/NIST.FIPS.180-4},
+  note        = {Specifies SHA-224, SHA-256, SHA-384, SHA-512, SHA-512/224, SHA-512/256}
+}
+
+@techreport{mccallister2010,
+  author      = {McCallister, Erika and Grance, Tim and Scarfone, Karen},
+  title       = {Guide to Protecting the Confidentiality of Personally Identifiable Information ({PII})},
+  number      = {Special Publication 800-122},
+  institution = {National Institute of Standards and Technology},
+  year        = {2010},
+  note        = {Endorses cryptographic hash functions with secret keys for de-identification}
+}
+
+@inproceedings{do2002coma,
+  author    = {Do, Hong-Hai and Rahm, Erhard},
+  title     = {{COMA}: A System for Flexible Combination of Schema Matching Approaches},
+  booktitle = {Proceedings of the 28th International Conference on Very Large Data Bases},
+  pages     = {610--621},
+  year      = {2002},
+  address   = {Hong Kong, China}
+}
+
+@inproceedings{madhavan2001cupid,
+  author    = {Madhavan, Jayant and Bernstein, Philip A. and Rahm, Erhard},
+  title     = {Generic Schema Matching with {Cupid}},
+  booktitle = {Proceedings of the 27th International Conference on Very Large Data Bases},
+  pages     = {49--58},
+  year      = {2001},
+  address   = {Rome, Italy}
+}
+
+@inproceedings{koutras2021valentine,
+  author    = {Koutras, Christos and Siachamis, George and Ionescu, Andra and Psarakis, Kyriakos and Brons, Jerry and Mami, Marios and Fragkoulis, Asterios and Lofi, Christoph and Bonifati, Angela and Katsifodimos, Asterios},
+  title     = {Valentine: Evaluating Matching Techniques for Dataset Discovery},
+  booktitle = {Proceedings of the IEEE 37th International Conference on Data Engineering},
+  pages     = {468--479},
+  year      = {2021},
+  doi       = {10.1109/ICDE51399.2021.00047}
+}
+
+@article{prasser2020arx,
+  author  = {Prasser, Fabian and Eicher, James and Spengler, Helmut and Bild, Raffael and Kuhn, Klaus A.},
+  title   = {Flexible Data Anonymization Using {ARX}: Current Status and Challenges Ahead},
+  journal = {Software: Practice and Experience},
+  volume  = {50},
+  number  = {7},
+  pages   = {1277--1304},
+  year    = {2020},
+  doi     = {10.1002/spe.2812}
+}
+
+@article{templ2015sdcmicro,
+  author  = {Templ, Matthias and Kowarik, Alexander and Meindl, Bernhard},
+  title   = {Statistical Disclosure Control for Micro-Data Using the {R} Package {sdcMicro}},
+  journal = {Journal of Statistical Software},
+  volume  = {67},
+  number  = {4},
+  pages   = {1--36},
+  year    = {2015},
+  doi     = {10.18637/jss.v067.i04}
 }


### PR DESCRIPTION
## Summary
- Expands `.inkwell/references/refs.bib` with additional privacy and de-identification literature used for citation examples.

## Test plan
- [x] `npm run verify` (pre-commit hook) passes
- [x] Demos that cite the bibliography still compile