### PR TITLE
fix(tex): map style files to provider packages

### DIFF
--- a/src/tex-requirements.ts
+++ b/src/tex-requirements.ts
@@ -69,7 +69,8 @@ export const TEX_PACKAGE_FILES: Readonly<Record<string, readonly string[]>> = {
     "booktabs.sty"
   ],
   "caption": [
-    "caption.sty"
+    "caption.sty",
+    "subcaption.sty"
   ],
   "microtype": [
     "microtype.sty"
@@ -217,7 +218,8 @@ export const TEX_PACKAGE_FILES: Readonly<Record<string, readonly string[]>> = {
     "array.sty",
     "calc.sty",
     "longtable.sty",
-    "multicol.sty"
+    "multicol.sty",
+    "tabularx.sty"
   ],
   "preprint": [
     "authblk.sty",
@@ -294,12 +296,6 @@ export const TEX_PACKAGE_FILES: Readonly<Record<string, readonly string[]>> = {
   ],
   "textcase": [
     "textcase.sty"
-  ],
-  "subcaption": [
-    "subcaption.sty"
-  ],
-  "tabularx": [
-    "tabularx.sty"
   ],
   "epstopdf-pkg": [
     "epstopdf.sty"

--- a/tests/doctor.test.cjs
+++ b/tests/doctor.test.cjs
@@ -119,9 +119,15 @@ test('installed requirements are authoritative and unknown packages have no fall
     assert.equal(f.calls.filter(call => call.name === 'kpsewhich' && !call.args[0].startsWith('-')).length, 0);
   }
   const installed = loadTexRequirements(path.join(__dirname, '..'));
-  assert.equal(installed.packages.length, 103);
+  assert.equal(installed.packages.length, 101);
   assert.ok(!installed.packages.some(pkg => pkg.name === 'fix2col'));
-  assert.deepEqual(installed.packages.find(pkg => pkg.name === 'tools').files, ['array.sty', 'calc.sty', 'longtable.sty', 'multicol.sty']);
+  assert.deepEqual(installed.packages.find(pkg => pkg.name === 'caption').files, ['caption.sty', 'subcaption.sty']);
+  assert.deepEqual(installed.packages.find(pkg => pkg.name === 'tools').files, ['array.sty', 'calc.sty', 'longtable.sty', 'multicol.sty', 'tabularx.sty']);
+  assert.equal(TEX_PACKAGE_FILES.subcaption, undefined);
+  assert.equal(TEX_PACKAGE_FILES.tabularx, undefined);
+  const providers = fixture(t, { requirements: 'caption\ntools\n', execute: (name, args) => name === 'kpsewhich' && ['subcaption.sty', 'tabularx.sty'].includes(args[0]) ? ok('', { exitCode: 1 }) : undefined });
+  const providerResult = await providers.doctor.run({ ...providers.options, mode: 'full' });
+  assert.deepEqual(providerResult.missingPackages, ['caption', 'tools']);
 });
 
 test('bundled templates do not import obsolete fix2col', () => {

--- a/tests/tex-provider-mapping.test.cjs
+++ b/tests/tex-provider-mapping.test.cjs
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const originalLoad = Module._load;
+Module._load = function(request, ...args) {
+  if (request === 'vscode') return {};
+  return originalLoad.call(this, request, ...args);
+};
+let tlmgrPackageForFile;
+try { ({ tlmgrPackageForFile } = require('../out/toolchain')); } finally { Module._load = originalLoad; }
+
+test('TeX style filenames resolve to their valid tlmgr provider packages', () => {
+  assert.equal(tlmgrPackageForFile('subcaption.sty'), 'caption');
+  assert.equal(tlmgrPackageForFile('tabularx.sty'), 'tools');
+});


### PR DESCRIPTION
## Summary

- map `subcaption.sty` and `tabularx.sty` to their valid `caption` and `tools` providers
- make Doctor and compiler quick fixes report those provider packages

## Validation

- source-backed Doctor and provider-mapping tests — 22 passing
- workflow and manifest tests — 19 passing
- `git diff --check`
