### PR TITLE
Preserve currency dollar signs in live preview

### DIFF
--- a/src/webview/client.js
+++ b/src/webview/client.js
@@ -443,7 +443,7 @@ export function startPreview(initial) {
       try { renderMathInElement = await assets.math(); } catch (error) { featureError("Math", error, generation); return; }
       if (generation !== articleGeneration) return;
       if (renderMathInElement) {
-        renderMathInElement(articleEl, {
+        var options = {
           ignoredClasses: ["inkwell-table-literal"],
           delimiters: [
             { left: "$$", right: "$$", display: true },
@@ -452,6 +452,15 @@ export function startPreview(initial) {
             { left: "\\(", right: "\\)", display: false }
           ],
           throwOnError: false
+        };
+        // The Markdown pass has already identified math using Pandoc's
+        // delimiter rules. Scanning the whole article again would turn
+        // ordinary currency into math as soon as any real formula is present.
+        articleEl.querySelectorAll("[data-inkwell-math]").forEach(function (element) {
+          // Auto-render's ignored tags/classes normally apply while walking
+          // descendants. Preserve those exclusions when starting at a wrapper.
+          if (element.closest("script, noscript, style, textarea, pre, code, option, .inkwell-table-literal")) return;
+          renderMathInElement(element, options);
         });
       }
     }

--- a/tests/offline-preview.test.cjs
+++ b/tests/offline-preview.test.cjs
@@ -160,11 +160,40 @@ test('real bundled preview renders math, Mermaid, code and bounded PDF pages wit
   const send = data => connection.evaluate(`window.dispatchEvent(new MessageEvent('message',{data:${JSON.stringify(data)}}))`);
   const base = { documentUri: 'file:///offline.md', sourceVersion: 1, revision: 1 };
   const html = '<h1>Offline rendering</h1><p><span data-inkwell-math="0">$x^2 + y^2 = z^2$</span></p>' +
+    '<div class="math-display" data-inkwell-math="1">$$a^2 + b^2 = c^2$$</div>' +
+    '<p><span data-inkwell-math="2">\\(x + y\\)</span></p><div class="math-display" data-inkwell-math="3">\\[z = 2\\]</div>' +
+    '<p class="currency-prose">Prices start at $20 and rise to $30.</p>' +
+    '<table><tbody><tr><td class="currency-cell"><strong>$20 at closing + up to $30 in milestones</strong></td></tr>' +
+    '<tr><td class="currency-cell">$5 upfront + $1–$2 annual minimum</td></tr>' +
+    '<tr><td class="inkwell-table-literal">$x$ and $20</td></tr></tbody></table>' +
+    '<p class="escaped-dollars">Escaped source dollars: $x$.</p><p><code class="literal-code">$x$ and $20</code></p>' +
     '<pre><code class="language-python">def answer():\n    return 42</code></pre><pre><code class="language-mermaid">graph TD; A[Local] --> B[Offline]</code></pre>';
   await connection.evaluate("document.querySelector('[data-tab=print]').click()");
   await send({ ...base, type: 'updateContent', html, pdfUri: resourceOrigin + '/fixture.pdf', title: 'Offline rendering' });
   await waitFor(() => connection.evaluate("!!document.querySelector('.katex') && !!document.querySelector('.mermaid svg') && !!document.querySelector('code.hljs .hljs-keyword')"));
   await waitFor(() => connection.evaluate("!!document.querySelector('#print-page-stage .katex') && !!document.querySelector('#print-page-stage .mermaid svg') && !!document.querySelector('#print-page-stage code.hljs .hljs-keyword')"));
+  for (const pane of ['#article-content', '#print-page-stage']) {
+    const math = await connection.evaluate(`(()=>{const root=document.querySelector(${JSON.stringify(pane)});return {
+      marked:root.querySelectorAll('[data-inkwell-math] .katex').length,
+      display:root.querySelectorAll('[data-inkwell-math] .katex-display').length,
+      unexpected:root.querySelectorAll('.currency-prose .katex,.currency-cell .katex,.escaped-dollars .katex,.literal-code .katex,.inkwell-table-literal .katex').length,
+      currency:root.querySelector('.currency-prose').textContent,
+      cells:[...root.querySelectorAll('.currency-cell')].map(cell=>cell.textContent),
+      bold:root.querySelector('.currency-cell strong')?.textContent,
+      escaped:root.querySelector('.escaped-dollars').textContent,
+      code:root.querySelector('.literal-code').textContent,
+      literal:root.querySelector('.inkwell-table-literal').textContent
+    };})()`);
+    assert.equal(math.marked, 4, pane + ': all supported marked math delimiters render');
+    assert.equal(math.display, 2, pane + ': both display math forms remain display math');
+    assert.equal(math.unexpected, 0, pane + ': dollars outside validated math remain literal');
+    assert.equal(math.currency, 'Prices start at $20 and rise to $30.');
+    assert.deepEqual(math.cells, ['$20 at closing + up to $30 in milestones', '$5 upfront + $1–$2 annual minimum']);
+    assert.equal(math.bold, '$20 at closing + up to $30 in milestones');
+    assert.equal(math.escaped, 'Escaped source dollars: $x$.');
+    assert.equal(math.code, '$x$ and $20');
+    assert.equal(math.literal, '$x$ and $20');
+  }
   assert.equal(requests.some(url => url.includes('pdfjs/')), false, 'PDF engine stays unloaded until the PDF tab opens');
   await connection.evaluate("document.querySelector('[data-tab=pdf]').click()");
   await waitFor(() => connection.evaluate('window.inkwellPreviewMetrics.renderedPages >= 6'));

--- a/tests/preview-safety.test.cjs
+++ b/tests/preview-safety.test.cjs
@@ -68,6 +68,31 @@ test('generated table cells cannot collide with math restoration or become math 
   assert.match(html, /class="inkwell-table-literal"[^>]*>\$x\$ &lt;b&gt;literal&lt;\/b&gt;<\/td>/);
 });
 
+test('preview marks real math while preserving currency and escaped dollar signs in draft and final HTML', async t => {
+  const h = host(t);
+  const document = h.document('currency-math.md', [
+    'Inline math: $x^2$.',
+    '$$a^2 + b^2 = c^2$$',
+    'Prices start at $20 and rise to $30.',
+    '| Option | Price |\n| --- | --- |\n| A | **$20 at closing + up to $30 in milestones** |\n| B | $5 upfront + $1–$2 annual minimum |',
+    'Escaped source dollars: \\$x\\$.',
+    'See @reference for context.',
+  ].join('\n\n'));
+  h.provider.currentDocument = document;
+  await h.provider.sendContentUpdate(document);
+  for (const type of ['draftContent', 'updateContent']) {
+    const html = h.messages.find(message => message.type === type).html;
+    assert.equal((html.match(/data-inkwell-math=/g) || []).length, 2, type + ': only real math is marked');
+    assert.match(html, /<span data-inkwell-math="\d+">\$x\^2\$<\/span>/);
+    assert.match(html, /<div class="math-display" data-inkwell-math="\d+">\$\$a\^2 \+ b\^2 = c\^2\$\$<\/div>/);
+    assert.match(html, /Prices start at \$20 and rise to \$30\./);
+    assert.match(html, /<strong>\$20 at closing \+ up to \$30 in milestones<\/strong>/);
+    assert.match(html, /\$5 upfront \+ \$1–\$2 annual minimum/);
+    assert.match(html, /Escaped source dollars: \$x\$\./);
+    assert.doesNotMatch(html, /INKWELLMATHPLACEHOLDER/);
+  }
+});
+
 // A small DOM adapter runs the actual shipped webview program. No repository
 // project data, browser process, PDF engine, or external resource is loaded.
 function client(provider, webview, globals = {}) {


### PR DESCRIPTION
Pages containing a real formula also sent ordinary prose through KaTeX's dollar-delimiter scanner. For example, currency amounts in a table could lose their dollar signs and spaces even though the Markdown parser had correctly left them as text.

Render math only inside the wrappers already identified by the Markdown pass, while preserving exclusions for code and literal generated table cells. Valid inline and display math continue to render in both the draft and print views.

Validation: regression coverage checks mixed currency and formulas, bold table text, escaped dollars, code, and all four supported math delimiters using the bundled browser renderer. The same browser regression fails against the previous renderer and passes with this fix. The complete repository verification also runs through the pre-commit hook.
